### PR TITLE
Use pnpm across setup scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,17 @@ FROM node:18-alpine AS base
 WORKDIR /app
 
 # نسخ ملفات تعريف الحزم
-COPY package.json package-lock.json ./
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
 
 # تثبيت الاعتماديات
 FROM base AS deps
-RUN npm ci
+RUN pnpm install --frozen-lockfile
 
 # بناء التطبيق
 FROM deps AS builder
 COPY . .
-RUN npm run build
+RUN pnpm run build
 
 # إنشاء صورة الإنتاج
 FROM base AS runner
@@ -40,4 +41,4 @@ ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
 # تشغيل التطبيق
-CMD ["npm", "start"]
+CMD ["pnpm", "start"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ BRANCH="main"
 
 # التحقق من وجود المتطلبات
 echo "التحقق من المتطلبات..."
-for cmd in git node npm; do
+for cmd in git node pnpm; do
     if ! command -v $cmd &> /dev/null; then
         echo "$cmd غير مثبت. الرجاء تثبيته قبل المتابعة."
         exit 1
@@ -36,7 +36,7 @@ fi
 
 # تثبيت الاعتماديات
 echo "تثبيت الاعتماديات..."
-npm ci
+pnpm install
 
 # إنشاء ملف .env إذا لم يكن موجودًا
 if [ ! -f "$APP_DIR/.env" ]; then
@@ -62,7 +62,7 @@ fi
 
 # بناء التطبيق
 echo "بناء التطبيق..."
-npm run build
+pnpm run build
 
 # تهيئة قاعدة البيانات
 echo "هل تريد تهيئة قاعدة البيانات؟ (y/n)"
@@ -75,7 +75,7 @@ fi
 # إعداد PM2 إذا لم يكن موجودًا
 if ! command -v pm2 &> /dev/null; then
     echo "تثبيت PM2..."
-    npm install -g pm2
+    pnpm add -g pm2
 fi
 
 # إنشاء ملف تكوين PM2
@@ -83,7 +83,7 @@ cat > ecosystem.config.js << EOL
 module.exports = {
   apps: [{
     name: "$APP_NAME",
-    script: "npm",
+    script: "pnpm",
     args: "start",
     instances: "max",
     exec_mode: "cluster",

--- a/init-db.sh
+++ b/init-db.sh
@@ -25,4 +25,4 @@ done
 
 # تهيئة قاعدة البيانات
 echo "تهيئة قاعدة البيانات..."
-npm run init-db
+pnpm run init-db

--- a/install-all.sh
+++ b/install-all.sh
@@ -111,16 +111,17 @@ FROM node:18-alpine AS base
 WORKDIR /app
 
 # نسخ ملفات تعريف الحزم
-COPY package.json package-lock.json ./
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
 
 # تثبيت الاعتماديات
 FROM base AS deps
-RUN npm ci
+RUN pnpm install --frozen-lockfile
 
 # بناء التطبيق
 FROM deps AS builder
 COPY . .
-RUN npm run build
+RUN pnpm run build
 
 # إنشاء صورة الإنتاج
 FROM base AS runner
@@ -146,7 +147,7 @@ ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
 # تشغيل التطبيق
-CMD ["npm", "start"]
+CMD ["pnpm", "start"]
 EOF
 
 # إنشاء ملف docker-compose.yml

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -9,7 +9,7 @@ USE_SSL=${USE_SSL:-false}
 
 # التحقق من وجود المتطلبات
 echo "التحقق من المتطلبات..."
-for cmd in git node npm; do
+for cmd in git node pnpm; do
     if ! command -v $cmd &> /dev/null; then
         echo "$cmd غير مثبت. جاري التثبيت..."
         sudo apt-get update
@@ -35,7 +35,7 @@ cd "$APP_DIR"
 
 # تثبيت الاعتماديات
 echo "تثبيت الاعتماديات..."
-npm ci
+pnpm install
 
 # إنشاء ملف .env
 echo "إنشاء ملف .env..."
@@ -49,7 +49,7 @@ sed -i "s/DB_PORT=.*/DB_PORT=$DB_PORT/" .env
 
 # بناء التطبيق
 echo "بناء التطبيق..."
-npm run build
+pnpm run build
 
 # إعداد PM2
 echo "إعداد PM2..."

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -42,6 +42,6 @@ export DB_PASSWORD=$DB_PASSWORD
 export DB_PORT=$DB_PORT
 
 # تشغيل سكريبت تهيئة قاعدة البيانات
-npm run init-db
+pnpm run init-db
 
 echo "تم إعداد قاعدة البيانات بنجاح!"

--- a/setup-github.sh
+++ b/setup-github.sh
@@ -98,7 +98,7 @@ cat > README.md << EOL
 
 2. تثبيت الاعتماديات:
    \`\`\`bash
-   npm install
+   pnpm install
    \`\`\`
 
 3. إعداد متغيرات البيئة:
@@ -109,12 +109,12 @@ cat > README.md << EOL
 
 4. تهيئة قاعدة البيانات:
    \`\`\`bash
-   npm run init-db
+   pnpm run init-db
    \`\`\`
 
 5. تشغيل التطبيق في وضع التطوير:
    \`\`\`bash
-   npm run dev
+   pnpm run dev
    \`\`\`
 
 ## النشر على الخادم

--- a/setup-pm2.sh
+++ b/setup-pm2.sh
@@ -7,7 +7,7 @@ APP_DIR="/var/www/$APP_NAME"
 # التحقق من تثبيت PM2
 if ! command -v pm2 &> /dev/null; then
     echo "PM2 غير مثبت. جاري التثبيت..."
-    npm install -g pm2
+    pnpm add -g pm2
 fi
 
 # إنشاء ملف تكوين PM2
@@ -15,7 +15,7 @@ cat > ecosystem.config.js << EOL
 module.exports = {
   apps: [{
     name: "$APP_NAME",
-    script: "npm",
+    script: "pnpm",
     args: "start",
     instances: "max",
     exec_mode: "cluster",


### PR DESCRIPTION
## Summary
- standardize on pnpm for dependency management
- update Dockerfile and installer to use pnpm
- switch setup scripts and deployment scripts to pnpm commands

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845c465935483308c72cfc71eeb583a