### PR TITLE
Add init-db script and update setup scripts

### DIFF
--- a/init-db.sh
+++ b/init-db.sh
@@ -25,4 +25,4 @@ done
 
 # تهيئة قاعدة البيانات
 echo "تهيئة قاعدة البيانات..."
-pnpm run init-db
+npm run init-db

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "init-db": "ts-node scripts/init-db.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -69,6 +70,7 @@
     "@types/react-dom": "^18",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10"
   }
 }

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -1,0 +1,21 @@
+import { initializeDatabase, seedDatabase, testConnection } from '../lib/db'
+
+async function main() {
+  try {
+    const connected = await testConnection()
+    if (!connected) {
+      console.error('فشل الاتصال بقاعدة البيانات')
+      process.exit(1)
+    }
+
+    await initializeDatabase()
+    await seedDatabase()
+
+    console.log('تم تهيئة قاعدة البيانات بنجاح')
+  } catch (error) {
+    console.error('خطأ في تهيئة قاعدة البيانات:', error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -42,6 +42,6 @@ export DB_PASSWORD=$DB_PASSWORD
 export DB_PORT=$DB_PORT
 
 # تشغيل سكريبت تهيئة قاعدة البيانات
-pnpm run init-db
+npm run init-db
 
 echo "تم إعداد قاعدة البيانات بنجاح!"

--- a/setup-github.sh
+++ b/setup-github.sh
@@ -109,7 +109,7 @@ cat > README.md << EOL
 
 4. تهيئة قاعدة البيانات:
    \`\`\`bash
-   pnpm run init-db
+   npm run init-db
    \`\`\`
 
 5. تشغيل التطبيق في وضع التطوير:


### PR DESCRIPTION
## Summary
- implement `scripts/init-db.ts` to setup database
- expose new `init-db` script in package.json
- update dev dependencies to include `ts-node`
- use `npm run init-db` in setup-db and init-db scripts
- fix GitHub setup instructions to use npm command

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845c759f8448330ad57027fc60a2a42