### PR TITLE
Add .env example and copy in setup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Database settings
+DB_USER=postgres
+DB_HOST=localhost
+DB_NAME=accounting_system
+DB_PASSWORD=your_password
+DB_PORT=5432
+
+# Redis settings (optional)
+REDIS_URL=redis://localhost:6379
+
+# Application settings
+NODE_ENV=production
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/install-all.sh
+++ b/install-all.sh
@@ -460,16 +460,12 @@ EOF
 # جعل سكريبت المراقبة قابل للتنفيذ
 chmod +x monitor.sh
 
-# إنشاء ملف .env لتخزين المتغيرات
-cat > .env << EOF
-DB_USER=postgres
-DB_HOST=db
-DB_NAME=accounting_system
-DB_PASSWORD=$DB_PASSWORD
-DB_PORT=5432
-REDIS_URL=redis://:$REDIS_PASSWORD@redis:6379
-APP_SECRET=$APP_SECRET
-EOF
+# إنشاء ملف .env من القالب
+cp .env.example .env
+sed -i "s/DB_HOST=.*/DB_HOST=db/" .env
+sed -i "s/DB_PASSWORD=.*/DB_PASSWORD=$DB_PASSWORD/" .env
+sed -i "s#REDIS_URL=.*#REDIS_URL=redis://:$REDIS_PASSWORD@redis:6379#" .env
+echo "APP_SECRET=$APP_SECRET" >> .env
 
 # إنشاء ملف .dockerignore
 cat > .dockerignore << 'EOF'

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -3,6 +3,11 @@
 # منح صلاحيات التنفيذ لسكريبت تهيئة قاعدة البيانات
 chmod +x init-db.sh
 
+# إنشاء ملف .env إذا لم يكن موجودًا
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
 # بناء وتشغيل الحاويات
 docker-compose up -d
 


### PR DESCRIPTION
## Summary
- provide `.env.example` template
- keep `.env.example` under version control
- generate `.env` from `.env.example` in install and docker scripts

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c93ae36c833093416df4d7dd192a