### PR TITLE
Fix init-db script and English messages

### DIFF
--- a/init-db.sh
+++ b/init-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# انتظار حتى تكون قاعدة البيانات جاهزة
-echo "انتظار حتى تكون قاعدة البيانات جاهزة..."
+# Wait until the database is ready
+echo "Waiting for the database to be ready..."
 until node -e "
 const { Pool } = require('pg');
 const pool = new Pool({
@@ -11,18 +11,18 @@ const pool = new Pool({
   password: process.env.DB_PASSWORD,
   port: process.env.DB_PORT,
 });
-pool.query('SELECT 1').then(() => {
-  console.log('تم الاتصال بقاعدة البيانات بنجاح');
+  pool.query('SELECT 1').then(() => {
+  console.log('Database connection successful');
   process.exit(0);
 }).catch(err => {
-  console.error('خطأ في الاتصال بقاعدة البيانات:', err);
+  console.error('Database connection error:', err);
   process.exit(1);
 });
 "; do
-  echo "قاعدة البيانات غير جاهزة بعد... انتظار 2 ثانية"
+  echo "Database not ready yet... waiting 2 seconds"
   sleep 2
 done
 
-# تهيئة قاعدة البيانات
-echo "تهيئة قاعدة البيانات..."
+# Initialize the database
+echo "Initializing the database..."
 pnpm run init-db

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "init-db": "node -e \"require('./lib/db').initializeDatabase().then(() => require('./lib/db').seedDatabase()).then(() => console.log('Database ready'))\""
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# منح صلاحيات التنفيذ لسكريبت تهيئة قاعدة البيانات
+# Make the init-db script executable
 chmod +x init-db.sh
 
-# بناء وتشغيل الحاويات
+# Build and start the containers
 docker-compose up -d
 
-# انتظار حتى تكون الخدمات جاهزة
-echo "انتظار حتى تكون الخدمات جاهزة..."
+# Wait for services to be ready
+echo "Waiting for services to be ready..."
 sleep 10
 
-# تهيئة قاعدة البيانات
+# Initialize the database
 docker-compose exec app ./init-db.sh
 
-echo "تم تشغيل التطبيق بنجاح!"
-echo "يمكنك الوصول إلى التطبيق على: http://localhost:3000"
+echo "Application started successfully!"
+echo "You can access the app at: http://localhost:3000"

--- a/setup-app.sh
+++ b/setup-app.sh
@@ -16,13 +16,13 @@ print_message() {
 
 # التحقق من وجود مجلد التطبيق
 if [ ! -d "app" ]; then
-  print_message "$RED" "خطأ: مجلد 'app' غير موجود. يرجى التأكد من تشغيل سكريبت 'install-all.sh' أولاً."
+print_message "$RED" "Error: 'app' directory not found. Please run 'install-all.sh' first."
   exit 1
 fi
 
 print_message "$BLUE" "
 =======================================================
-      إعداد كود التطبيق لنظام المحاسبة والتوزيع
+      Setting up application code for the accounting system
 =======================================================
 "
 
@@ -44,10 +44,10 @@ mkdir -p app/app/dashboard
 mkdir -p app/app/login
 mkdir -p app/public/images
 
-print_message "$GREEN" "✓ تم إنشاء هيكل المجلدات بنجاح"
+print_message "$GREEN" "✓ Folder structure created successfully"
 
 # نسخ ملفات التطبيق من المجلد الحالي إلى مجلد app
-print_message "$YELLOW" "جاري نسخ ملفات التطبيق..."
+print_message "$YELLOW" "Copying application files..."
 
 # قائمة بالملفات التي يجب نسخها
 FILES_TO_COPY=(
@@ -88,46 +88,46 @@ FILES_TO_COPY=(
   "tailwind.config.ts"
 )
 
-# نسخ الملفات إذا كانت موجودة
+# Copy files if they exist
 for file in "${FILES_TO_COPY[@]}"; do
   if [ -f "$file" ]; then
-    # إنشاء المجلد الهدف إذا لم يكن موجودًا
+    # Create target directory if it does not exist
     mkdir -p "app/$(dirname "$file")"
-    # نسخ الملف
+    # Copy the file
     cp "$file" "app/$file"
-    echo "تم نسخ: $file"
+    echo "Copied: $file"
   else
-    echo "تخطي: $file (غير موجود)"
+    echo "Skipped: $file (not found)"
   fi
 done
 
-# نسخ الصور إذا كانت موجودة
+# Copy images if they exist
 if [ -d "public/images" ]; then
   cp -r public/images/* app/public/images/
-  echo "تم نسخ: الصور"
+  echo "Copied: images"
 fi
 
-print_message "$GREEN" "✓ تم نسخ ملفات التطبيق بنجاح"
+print_message "$GREEN" "✓ Application files copied successfully"
 
 # بناء وتشغيل الحاويات
-print_message "$YELLOW" "جاري بناء وتشغيل الحاويات..."
+print_message "$YELLOW" "Building and starting containers..."
 docker-compose up -d --build
 
-print_message "$GREEN" "✓ تم بناء وتشغيل الحاويات بنجاح"
+print_message "$GREEN" "✓ Containers built and started successfully"
 
 # انتظار حتى تكون قاعدة البيانات جاهزة
-print_message "$YELLOW" "انتظار حتى تكون قاعدة البيانات جاهزة..."
+print_message "$YELLOW" "Waiting for the database to be ready..."
 sleep 10
 
-print_message "$GREEN" "✓ تم إعداد التطبيق بنجاح!"
+print_message "$GREEN" "✓ Application setup complete!"
 print_message "$BLUE" "
 =======================================================
-                معلومات الوصول
+                Access information
 =======================================================
 "
 
-print_message "$YELLOW" "يمكنك الوصول إلى التطبيق على: http://localhost:3000"
-print_message "$YELLOW" "يمكنك الوصول إلى التطبيق من خلال Nginx على: http://localhost"
+print_message "$YELLOW" "You can access the app at: http://localhost:3000"
+print_message "$YELLOW" "You can access the app through Nginx at: http://localhost"
 
 print_message "$BLUE" "
 للمزيد من المعلومات، راجع ملف 'connection-info.txt'

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
-# تكوين المتغيرات
+# Configure variables
 DB_USER=${DB_USER:-postgres}
 DB_HOST=${DB_HOST:-localhost}
 DB_NAME=${DB_NAME:-accounting_system}
 DB_PASSWORD=${DB_PASSWORD:-postgres}
 DB_PORT=${DB_PORT:-5432}
 
-# التحقق من تثبيت PostgreSQL
+# Check for PostgreSQL installation
 if ! command -v psql &> /dev/null; then
-    echo "PostgreSQL غير مثبت. جاري التثبيت..."
+    echo "PostgreSQL is not installed. Installing..."
     sudo apt-get update
     sudo apt-get install -y postgresql postgresql-contrib
 fi
 
-# إنشاء قاعدة البيانات والمستخدم
-echo "إنشاء قاعدة البيانات والمستخدم..."
+# Create database and user
+echo "Creating database and user..."
 sudo -u postgres psql << EOF
 -- إنشاء المستخدم إذا لم يكن موجودًا
 DO \$\$
@@ -33,8 +33,8 @@ SELECT 'CREATE DATABASE $DB_NAME' WHERE NOT EXISTS (SELECT FROM pg_database WHER
 GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;
 EOF
 
-# تهيئة قاعدة البيانات
-echo "تهيئة قاعدة البيانات..."
+# Initialize the database
+echo "Initializing the database..."
 export DB_USER=$DB_USER
 export DB_HOST=$DB_HOST
 export DB_NAME=$DB_NAME
@@ -44,4 +44,4 @@ export DB_PORT=$DB_PORT
 # تشغيل سكريبت تهيئة قاعدة البيانات
 pnpm run init-db
 
-echo "تم إعداد قاعدة البيانات بنجاح!"
+echo "Database setup completed!"


### PR DESCRIPTION
## Summary
- add `init-db` script in `package.json`
- translate install messages in `init-db.sh`, `setup-db.sh`, `run-docker.sh`
- switch several setup messages in `setup-app.sh` to English

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6845df0887c48330aa6a37acc88d95e0