### PR TITLE
Fix init-db script and document PM2 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ REDIS_URL=redis://localhost:6379
 4. Initialize the database:
 
 ```bash
-node -e "require('./lib/db').initializeDatabase().then(() => require('./lib/db').seedDatabase()).then(() => console.log('Database ready'))"
+pnpm run init-db
 ```
 
 5. Start the development server:
@@ -72,4 +72,46 @@ pnpm start
 ## Custom reports
 
 The dashboard includes a **Custom Reports** tab where you can define your own reports. Choose a report type, enter a name and comma separated columns, then add the report. Reports can be removed from the same tab. They are stored in the database via `/api/custom-reports`.
+
+## Managing the application
+
+For production deployments the application can be managed using **PM2**. After running `setup-pm2.sh` an `ecosystem.config.js` file is generated and the app is registered with the name `accounting-system`.
+
+- **Start** the application
+
+  ```bash
+  pm2 start ecosystem.config.js
+  ```
+
+- **Stop** the application
+
+  ```bash
+  pm2 stop accounting-system
+  ```
+
+- **Restart** the application
+
+  ```bash
+  pm2 restart accounting-system
+  ```
+
+- **Check status**
+
+  ```bash
+  pm2 status
+  ```
+
+- **Update** the application
+
+  ```bash
+  git pull
+  pnpm install
+  pm2 restart accounting-system
+  ```
+
+- **Delete** the PM2 process
+
+  ```bash
+  pm2 delete accounting-system
+  ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "init-db": "node -e \"require('./lib/db').initializeDatabase().then(() => require('./lib/db').seedDatabase()).then(() => console.log('Database ready'))\""
+    "init-db": "ts-node ./lib/db.ts && echo 'Database ready'"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -70,6 +70,7 @@
     "@types/react-dom": "^18",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- run database initialization with ts-node
- document new init-db command
- add instructions for PM2 management

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5d2b07c8330bb38b887d3666da8