### PR TITLE
Fix setup scripts and translate messages to English

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -52,7 +52,7 @@ export default function Dashboard() {
         .map(([productId, data]) => {
           const product = productsData.find((p) => p.id === productId)
           return {
-            name: product?.name || "غير معروف",
+            name: product?.name || "Unknown",
             quantity: data.quantity,
             revenue: data.revenue,
           }
@@ -76,7 +76,7 @@ export default function Dashboard() {
       const centerPerformanceData = Object.entries(centerSales).map(([centerId, data]) => {
         const center = centersData.find((c) => c.id === centerId)
         return {
-          name: center?.name || "غير معروف",
+          name: center?.name || "Unknown",
           revenue: data.revenue,
         }
       })

--- a/components/distribution-centers.tsx
+++ b/components/distribution-centers.tsx
@@ -216,7 +216,7 @@ export default function DistributionCenters() {
 
         return {
           ...sale,
-          productName: product?.name || "غير معروف",
+          productName: product?.name || "Unknown",
           revenue: saleRevenue,
         }
       })

--- a/components/inventory.tsx
+++ b/components/inventory.tsx
@@ -167,7 +167,7 @@ export default function Inventory() {
   }
 
   const getCenterById = (centerId: string) => {
-    return centers.find((center) => center.id === centerId) || { name: "غير معروف" }
+    return centers.find((center) => center.id === centerId) || { name: "Unknown" }
   }
 
   return (
@@ -517,7 +517,7 @@ export default function Inventory() {
                                     const product = products.find((p) => p.id === item.productId)
                                     return (
                                       <TableRow key={item.id}>
-                                        <TableCell>{product?.name || "غير معروف"}</TableCell>
+                                        <TableCell>{product?.name || "Unknown"}</TableCell>
                                         <TableCell>{item.initialQuantity}</TableCell>
                                         <TableCell>{item.currentQuantity}</TableCell>
                                         <TableCell>{new Date(item.lastUpdated).toLocaleDateString()}</TableCell>

--- a/components/sales.tsx
+++ b/components/sales.tsx
@@ -407,8 +407,8 @@ export default function Sales() {
                   const center = centers.find((c) => c.id === sale.centerId)
                   return (
                     <TableRow key={sale.id}>
-                      <TableCell className="font-medium">{product?.name || "غير معروف"}</TableCell>
-                      <TableCell>{center?.name || "غير معروف"}</TableCell>
+                      <TableCell className="font-medium">{product?.name || "Unknown"}</TableCell>
+                      <TableCell>{center?.name || "Unknown"}</TableCell>
                       <TableCell>{sale.quantity}</TableCell>
                       <TableCell>{sale.price.toLocaleString()} ل.س</TableCell>
                       <TableCell>{(sale.quantity * sale.price).toLocaleString()} ل.س</TableCell>

--- a/init-db.sh
+++ b/init-db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# انتظار حتى تكون قاعدة البيانات جاهزة
-echo "انتظار حتى تكون قاعدة البيانات جاهزة..."
+# Wait until the database is ready
+echo "Waiting for the database to be ready..."
 until node -e "
 const { Pool } = require('pg');
 const pool = new Pool({
@@ -12,17 +12,17 @@ const pool = new Pool({
   port: process.env.DB_PORT,
 });
 pool.query('SELECT 1').then(() => {
-  console.log('تم الاتصال بقاعدة البيانات بنجاح');
+  console.log('Database connection successful');
   process.exit(0);
 }).catch(err => {
-  console.error('خطأ في الاتصال بقاعدة البيانات:', err);
+  console.error('Database connection error:', err);
   process.exit(1);
 });
 "; do
-  echo "قاعدة البيانات غير جاهزة بعد... انتظار 2 ثانية"
+  echo "Database not ready yet... waiting 2 seconds"
   sleep 2
 done
 
-# تهيئة قاعدة البيانات
-echo "تهيئة قاعدة البيانات..."
+# Initialize the database
+echo "Initializing the database..."
 pnpm run init-db

--- a/lib/data-utils.ts
+++ b/lib/data-utils.ts
@@ -320,7 +320,7 @@ export const getProductInventoryReport = (productId: string) => {
       const center = centers.find((c) => c.id === item.centerId)
       return {
         ...item,
-        centerName: center?.name || "غير معروف",
+        centerName: center?.name || "Unknown",
         centerAddress: center?.address || "",
         centerContact: center?.contactPerson || "",
       }
@@ -344,7 +344,7 @@ export const getCenterInventoryReport = (centerId: string) => {
       const product = products.find((p) => p.id === item.productId)
       return {
         ...item,
-        productName: product?.name || "غير معروف",
+        productName: product?.name || "Unknown",
         productBrand: product?.brand || "",
         productCategory: product?.category || "",
         productPrice: product?.price || 0,
@@ -382,7 +382,7 @@ export const getSalesByCenterReport = (centerId: string, startDate?: string, end
         const product = products.find((p) => p.id === sale.productId)
         return {
           ...sale,
-          productName: product?.name || "غير معروف",
+          productName: product?.name || "Unknown",
           productBrand: product?.brand || "",
           productCategory: product?.category || "",
           totalAmount: sale.quantity * sale.price,

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# منح صلاحيات التنفيذ لسكريبت تهيئة قاعدة البيانات
+# Grant execute permission for the database init script
 chmod +x init-db.sh
 
-# بناء وتشغيل الحاويات
+# Build and start containers
 docker-compose up -d
 
-# انتظار حتى تكون الخدمات جاهزة
-echo "انتظار حتى تكون الخدمات جاهزة..."
+# Wait until services are ready
+echo "Waiting for services to be ready..."
 sleep 10
 
-# تهيئة قاعدة البيانات
+# Initialize the database
 docker-compose exec app ./init-db.sh
 
-echo "تم تشغيل التطبيق بنجاح!"
-echo "يمكنك الوصول إلى التطبيق على: http://localhost:3000"
+echo "Application started successfully!"
+echo "You can access the app at: http://localhost:3000"

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -1,91 +1,104 @@
 #!/bin/bash
 
-# تكوين المتغيرات
+# Variable configuration
 APP_NAME="accounting-system"
-GITHUB_USERNAME="your-github-username"  # قم بتغيير هذا إلى اسم المستخدم الخاص بك على GitHub
+GITHUB_USERNAME="your-github-username"  # Change this to your GitHub username
 GITHUB_REPO="accounting-distribution-system"
-# اسم النطاق اختياري. الافتراضي هو localhost ويمكن تعديله لاحقًا
+# Optional domain name. Defaults to localhost and can be changed later
 DOMAIN=${DOMAIN:-localhost}
 USE_SSL=${USE_SSL:-false}
 
-# السماح بتحديد نطاق مخصص عند التشغيل
-read -p "أدخل اسم النطاق (الافتراضي: $DOMAIN): " DOMAIN_INPUT
+# Allow providing a custom domain when running the script
+read -p "Enter domain name (default: $DOMAIN): " DOMAIN_INPUT
 DOMAIN=${DOMAIN_INPUT:-$DOMAIN}
 
-# التحقق من وجود المتطلبات
-echo "التحقق من المتطلبات..."
+# Check prerequisites
+echo "Checking prerequisites..."
 for cmd in git node pnpm; do
     if ! command -v $cmd &> /dev/null; then
-        echo "$cmd غير مثبت. جاري التثبيت..."
+        echo "$cmd is not installed. Installing..."
         sudo apt-get update
         sudo apt-get install -y $cmd
     fi
 done
 
-# إعداد قاعدة البيانات
-echo "إعداد قاعدة البيانات..."
-./setup-db.sh
+# Set up the database
+echo "Setting up the database..."
+bash ./setup-db.sh
 
-# إعداد Redis
-echo "إعداد Redis..."
-./setup-redis.sh
+# Set up Redis
+echo "Setting up Redis..."
+bash ./setup-redis.sh
 
-# استنساخ المستودع
-echo "استنساخ المستودع..."
+# Clone the repository
+echo "Cloning repository..."
 APP_DIR="/var/www/$APP_NAME"
 sudo mkdir -p "$APP_DIR"
 sudo chown $(whoami):$(whoami) "$APP_DIR"
 if [ -d "$APP_DIR/.git" ]; then
-    echo "المجلد موجود. سيتم تحديث المستودع..."
+    echo "Directory exists. Updating repository..."
     git -C "$APP_DIR" pull
 else
     git clone https://github.com/$GITHUB_USERNAME/$GITHUB_REPO.git "$APP_DIR"
 fi
 cd "$APP_DIR"
 
-# تثبيت الاعتماديات
-echo "تثبيت الاعتماديات..."
-pnpm install
+# Install dependencies
+echo "Installing dependencies..."
+rm -rf node_modules
+pnpm install --force
 
-# إنشاء ملف .env
-echo "إنشاء ملف .env..."
-cp .env.example .env
-# تحديث ملف .env بإعدادات قاعدة البيانات
+# Create .env file
+echo "Creating .env file..."
+if [ -f .env.example ]; then
+    cp .env.example .env
+else
+    cat > .env <<EOF_ENV
+DB_USER=$DB_USER
+DB_HOST=$DB_HOST
+DB_NAME=$DB_NAME
+DB_PASSWORD=$DB_PASSWORD
+DB_PORT=$DB_PORT
+EOF_ENV
+fi
+
+# Update .env with database settings
 sed -i "s/DB_USER=.*/DB_USER=$DB_USER/" .env
 sed -i "s/DB_HOST=.*/DB_HOST=$DB_HOST/" .env
 sed -i "s/DB_NAME=.*/DB_NAME=$DB_NAME/" .env
 sed -i "s/DB_PASSWORD=.*/DB_PASSWORD=$DB_PASSWORD/" .env
 sed -i "s/DB_PORT=.*/DB_PORT=$DB_PORT/" .env
 
-# بناء التطبيق
-echo "بناء التطبيق..."
+# Build the application
+echo "Building the application..."
 pnpm run build
 
-# إعداد PM2
-echo "إعداد PM2..."
-./setup-pm2.sh
+# Configure PM2
+echo "Configuring PM2..."
+bash ./setup-pm2.sh
 
-# إعداد Nginx
-echo "إعداد Nginx..."
+# Configure Nginx
+echo "Configuring Nginx..."
 USE_SSL=$USE_SSL DOMAIN=$DOMAIN ./setup-nginx.sh
 
-# إعداد النسخ الاحتياطي
-echo "إعداد النسخ الاحتياطي..."
+# Configure backups
+echo "Configuring backups..."
 sudo cp backup-db.sh /usr/local/bin/
 sudo chmod +x /usr/local/bin/backup-db.sh
 # إضافة مهمة cron لتشغيل النسخ الاحتياطي يوميًا في الساعة 2 صباحًا
 (crontab -l 2>/dev/null; echo "0 2 * * * /usr/local/bin/backup-db.sh") | crontab -
 
-# إعداد Fail2Ban
-echo "إعداد Fail2Ban..."
-./setup-fail2ban.sh
+# Configure Fail2Ban
+echo "Configuring Fail2Ban..."
+bash ./setup-fail2ban.sh
 
-# إعداد المراقبة
-echo "إعداد المراقبة..."
-./setup-monitoring.sh
+# Configure monitoring
+echo "Configuring monitoring..."
+bash ./setup-monitoring.sh
 
-echo "تم إعداد النظام بنجاح!"
-echo "يمكنك الوصول إلى التطبيق على: http://$DOMAIN"
+# Final message
+echo "System setup complete!"
+echo "You can access the application at: http://$DOMAIN"
 if [ "$USE_SSL" = "true" ]; then
-    echo "أو: https://$DOMAIN"
+    echo "Or: https://$DOMAIN"
 fi

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
-# تكوين المتغيرات
+# Variable configuration
 DB_USER=${DB_USER:-postgres}
 DB_HOST=${DB_HOST:-localhost}
 DB_NAME=${DB_NAME:-accounting_system}
 DB_PASSWORD=${DB_PASSWORD:-postgres}
 DB_PORT=${DB_PORT:-5432}
 
-# التحقق من تثبيت PostgreSQL
+# Ensure PostgreSQL is installed
 if ! command -v psql &> /dev/null; then
-    echo "PostgreSQL غير مثبت. جاري التثبيت..."
+    echo "PostgreSQL is not installed. Installing..."
     sudo apt-get update
     sudo apt-get install -y postgresql postgresql-contrib
 fi
 
-# إنشاء قاعدة البيانات والمستخدم
-echo "إنشاء قاعدة البيانات والمستخدم..."
+# Create database and user
+echo "Creating database and user..."
 sudo -u postgres psql << EOF
 -- إنشاء المستخدم إذا لم يكن موجودًا
 DO \$\$
@@ -33,15 +33,15 @@ SELECT 'CREATE DATABASE $DB_NAME' WHERE NOT EXISTS (SELECT FROM pg_database WHER
 GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;
 EOF
 
-# تهيئة قاعدة البيانات
-echo "تهيئة قاعدة البيانات..."
+# Initialize the database
+echo "Initializing the database..."
 export DB_USER=$DB_USER
 export DB_HOST=$DB_HOST
 export DB_NAME=$DB_NAME
 export DB_PASSWORD=$DB_PASSWORD
 export DB_PORT=$DB_PORT
 
-# تشغيل سكريبت تهيئة قاعدة البيانات
+# Run database initialization script
 pnpm run init-db
 
-echo "تم إعداد قاعدة البيانات بنجاح!"
+echo "Database setup complete!"

--- a/setup-fail2ban.sh
+++ b/setup-fail2ban.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# التحقق من تثبيت Fail2Ban
+# Ensure Fail2Ban is installed
 if ! command -v fail2ban-server &> /dev/null; then
-    echo "Fail2Ban غير مثبت. جاري التثبيت..."
+    echo "Fail2Ban is not installed. Installing..."
     sudo apt-get update
     sudo apt-get install -y fail2ban
 fi
 
-# إنشاء ملف تكوين Fail2Ban
+# Create Fail2Ban configuration
 sudo tee /etc/fail2ban/jail.local > /dev/null << EOL
 [sshd]
 enabled = true
@@ -26,7 +26,7 @@ maxretry = 5
 bantime = 3600
 EOL
 
-# إعادة تشغيل Fail2Ban
+# Restart Fail2Ban
 sudo systemctl restart fail2ban
 
-echo "تم إعداد Fail2Ban بنجاح!"
+echo "Fail2Ban setup complete!"

--- a/setup-monitoring.sh
+++ b/setup-monitoring.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-# تثبيت Prometheus
-echo "تثبيت Prometheus..."
+# Install Prometheus
+echo "Installing Prometheus..."
 sudo apt-get update
 sudo apt-get install -y prometheus
 
-# تثبيت Grafana
-echo "تثبيت Grafana..."
+# Install Grafana
+echo "Installing Grafana..."
 sudo apt-get install -y apt-transport-https software-properties-common
 sudo add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y grafana
 
-# تكوين Prometheus
+# Configure Prometheus
 sudo tee /etc/prometheus/prometheus.yml > /dev/null << EOL
 global:
   scrape_interval: 15s
@@ -33,13 +33,13 @@ scrape_configs:
       - targets: ['localhost:3000']
 EOL
 
-# تشغيل الخدمات
+# Start services
 sudo systemctl enable prometheus
 sudo systemctl start prometheus
 sudo systemctl enable grafana-server
 sudo systemctl start grafana-server
 
-echo "تم إعداد Prometheus و Grafana بنجاح!"
-echo "يمكنك الوصول إلى Grafana على: http://your-server-ip:3000"
-echo "اسم المستخدم الافتراضي: admin"
-echo "كلمة المرور الافتراضية: admin"
+echo "Prometheus and Grafana setup complete!"
+echo "Access Grafana at: http://your-server-ip:3000"
+echo "Default username: admin"
+echo "Default password: admin"

--- a/setup-pm2.sh
+++ b/setup-pm2.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# تكوين المتغيرات
+# Variable configuration
 APP_NAME="accounting-system"
 APP_DIR="/var/www/$APP_NAME"
 
-# التحقق من تثبيت PM2
+# Ensure PM2 is installed
 if ! command -v pm2 &> /dev/null; then
-    echo "PM2 غير مثبت. جاري التثبيت..."
+    echo "PM2 is not installed. Installing..."
     pnpm add -g pm2
 fi
 
-# إنشاء ملف تكوين PM2
+# Create PM2 configuration file
 cat > ecosystem.config.js << EOL
 module.exports = {
   apps: [{
@@ -35,12 +35,12 @@ module.exports = {
 };
 EOL
 
-# تشغيل التطبيق باستخدام PM2
-echo "تشغيل التطبيق باستخدام PM2..."
+# Start the application with PM2
+echo "Starting application with PM2..."
 pm2 start ecosystem.config.js
 
-# تكوين PM2 للتشغيل عند بدء النظام
+# Configure PM2 to run on system startup
 pm2 save
 pm2 startup | grep -v "sudo" | bash
 
-echo "تم إعداد PM2 بنجاح!"
+echo "PM2 setup complete!"

--- a/setup-redis.sh
+++ b/setup-redis.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# التحقق من تثبيت Redis
+# Ensure Redis is installed
 if ! command -v redis-server &> /dev/null; then
-    echo "Redis غير مثبت. جاري التثبيت..."
+    echo "Redis is not installed. Installing..."
     sudo apt-get update
     sudo apt-get install -y redis-server
 fi
 
-# تكوين Redis للتشغيل عند بدء النظام
+# Configure Redis to start on boot
 sudo systemctl enable redis-server
 sudo systemctl start redis-server
 
-# التحقق من حالة Redis
+# Check Redis status
 sudo systemctl status redis-server
 
-echo "تم إعداد Redis بنجاح!"
+echo "Redis setup complete!"


### PR DESCRIPTION
## Summary
- translate Arabic messages and comments in setup scripts to English
- improve `setup-all.sh` to recreate `.env` if missing, reinstall dependencies, and use bash for sub-scripts
- translate some component fallback strings to "Unknown"

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fpg: Forbidden - 403)*
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684608c922808330858f0f29aef5533d