### PR TITLE
Fix init-db script for missing ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "init-db": "ts-node-esm ./lib/db.ts && echo 'Database ready'"
+    "init-db": "ts-node -P tsconfig.init.json ./lib/db.ts && echo 'Database ready'"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/tsconfig.init.json
+++ b/tsconfig.init.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "include": ["lib/db.ts"]
+}


### PR DESCRIPTION
## Summary
- adjust `init-db` script to run ts-node with a custom config
- add `tsconfig.init.json` for database initialization

## Testing
- `pnpm lint`
- `pnpm run init-db`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6846255ded8c83308412c45cff258ad3