### PR TITLE
Fix dynamic route build errors

### DIFF
--- a/app/api/centers/route.ts
+++ b/app/api/centers/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
 import {
   getDistributionCenters,
   addDistributionCenter,

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
 import { getProducts, addProduct, updateProduct, deleteProduct } from "@/lib/db"
 
 export async function GET() {

--- a/app/api/reports/center-sales/[id]/route.ts
+++ b/app/api/reports/center-sales/[id]/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
 import { getSalesByCenterReport } from "@/lib/db"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {

--- a/app/api/reports/inventory-log/route.ts
+++ b/app/api/reports/inventory-log/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
 import { getInventoryLog } from "@/lib/db"
 
 export async function GET(request: NextRequest) {

--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
 import { getSales, addSale, deleteSale } from "@/lib/db"
 
 export async function GET() {


### PR DESCRIPTION
## Summary
- mark API routes as dynamic to avoid build errors with `nextUrl.searchParams`

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd255c088330826adeafadc0ce4c