### PR TITLE
Fix pm2 startup script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -103,7 +103,8 @@ pm2 startOrRestart ecosystem.config.js
 
 # تكوين PM2 للتشغيل عند بدء النظام
 pm2 save
-pm2 startup | grep -v "sudo" | bash
+# Use the recommended startup command directly instead of piping output to bash
+pm2 startup systemd -u "$(whoami)" --hp "$HOME"
 
 # إعداد Nginx إذا لم يكن موجودًا
 if ! command -v nginx &> /dev/null; then

--- a/setup-pm2.sh
+++ b/setup-pm2.sh
@@ -41,6 +41,7 @@ pm2 start ecosystem.config.js
 
 # تكوين PM2 للتشغيل عند بدء النظام
 pm2 save
-pm2 startup | grep -v "sudo" | bash
+# Use the recommended startup command directly instead of piping output to bash
+pm2 startup systemd -u "$(whoami)" --hp "$HOME"
 
 echo "PM2 setup completed successfully!"


### PR DESCRIPTION
## Summary
- fix pm2 startup command in deploy and setup scripts

## Testing
- `pnpm run lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm install` *(fails: ERR_PNPM_FETCH_403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846de603c5c8330a6e3eedb816e8ee8