### PR TITLE
Improve Grafana install error handling

### DIFF
--- a/setup-monitoring.sh
+++ b/setup-monitoring.sh
@@ -19,7 +19,10 @@ echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://packages.grafana.com
   sudo tee /etc/apt/sources.list.d/grafana.list
 
 sudo apt-get update
-sudo apt-get install -y grafana
+if ! sudo apt-get install -y grafana; then
+  echo "Failed to install Grafana. Please check your network connection and repository configuration." >&2
+  exit 1
+fi
 
 # تكوين Prometheus
 sudo tee /etc/prometheus/prometheus.yml > /dev/null << EOL


### PR DESCRIPTION
## Summary
- add error handling to `setup-monitoring.sh` when installing Grafana

## Testing
- `pnpm lint` *(fails: next not found / modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7ef14b88330a7219ae11c99e88e