### PR TITLE
Improve service status feedback and firewall setup

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -14,12 +14,14 @@ cd "$APP_DIR" 2>/dev/null || {
 case "$COMMAND" in
   start)
     pm2 start ecosystem.config.js
+    pm2 status "$APP_NAME"
     ;;
   stop)
     pm2 stop "$APP_NAME"
     ;;
   restart)
     pm2 restart "$APP_NAME"
+    pm2 status "$APP_NAME"
     ;;
   status)
     pm2 status "$APP_NAME"

--- a/README.md
+++ b/README.md
@@ -115,3 +115,24 @@ This command runs from `/var/www/accounting-system`, so you can invoke `NexAccou
   NexAccount Delete
   ```
 
+### Accessing the application
+
+After running `setup-all.sh`, the install summary shows whether HTTPS was enabled. By default the site is available at:
+
+- **HTTP**: `http://<your-domain-or-ip>` on port **80**
+- **HTTPS**: `https://<your-domain-or-ip>` on port **443`** (when SSL is enabled)
+
+### Service logs
+
+Logs for the major components can be found in the following locations:
+
+- **Nginx**: `/var/log/nginx/`
+- **PM2/Application**: `~/.pm2/logs/`
+- **PostgreSQL**: `/var/log/postgresql/`
+- **Fail2Ban**: `/var/log/fail2ban.log`
+- **UFW firewall**: `/var/log/ufw.log`
+
+### Firewall
+
+`setup-firewall.sh` configures UFW to open ports 22, 80, 443 and 3000 so the project operates correctly.
+

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -104,6 +104,10 @@ sudo chmod +x /usr/local/bin/backup-db.sh
 echo "Setting up Fail2Ban..."
 ./setup-fail2ban.sh
 
+# إعداد الجدار الناري
+echo "Configuring the firewall..."
+./setup-firewall.sh
+
 # إعداد المراقبة
 echo "Setting up monitoring..."
 ./setup-monitoring.sh

--- a/setup-firewall.sh
+++ b/setup-firewall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Ensure UFW is installed
+if ! command -v ufw &> /dev/null; then
+    echo "UFW is not installed. Installing..."
+    sudo apt-get update
+    sudo apt-get install -y ufw
+fi
+
+# Allow essential ports for the accounting system
+sudo ufw allow 22
+sudo ufw allow 80
+sudo ufw allow 443
+sudo ufw allow 3000
+
+# Enable the firewall if not already enabled
+STATUS=$(sudo ufw status | head -n1)
+if [[ "$STATUS" == "Status: inactive" ]]; then
+    sudo ufw --force enable
+fi
+
+sudo ufw status verbose
+
+echo "Firewall configured successfully!"


### PR DESCRIPTION
## Summary
- add a `setup-firewall.sh` script to configure UFW
- call the firewall script from `setup-all.sh`
- print service status when running `NexAccount Start` or `NexAccount Restart`
- document service URLs, log locations and firewall setup in README

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e9b99c548330b9c666f6f8f10a12