### PR TITLE
Improve status feedback

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -5,6 +5,41 @@ APP_NAME="accounting-system"
 # Directory where the application is installed
 APP_DIR="/var/www/$APP_NAME"
 
+# Determine domain and access information
+get_domain() {
+  grep -oP 'server_name\s+\K[^;]+' \
+    "/etc/nginx/sites-available/$APP_NAME" 2>/dev/null | head -n1
+}
+
+print_access_info() {
+  local domain=$(get_domain)
+  [ -z "$domain" ] && domain="localhost"
+  local ip_address=$(hostname -I | awk '{print $1}')
+  local ssl_enabled="false"
+  grep -q 'listen 443' "/etc/nginx/sites-available/$APP_NAME" 2>/dev/null && ssl_enabled="true"
+
+  echo ""
+  echo "Access the application via:"
+  echo " - HTTP:  http://$domain (IP: $ip_address, port 80)"
+  if [ "$ssl_enabled" = "true" ]; then
+    echo " - HTTPS: https://$domain (IP: $ip_address, port 443)"
+  fi
+}
+
+print_service_status() {
+  local db_status=$(systemctl is-active postgresql || true)
+  local redis_status=$(systemctl is-active redis-server || true)
+  local nginx_status=$(systemctl is-active nginx || true)
+  local pm2_status=$(pm2 status "$APP_NAME" | grep -q online && echo "online" || echo "offline")
+
+  echo "==== Service Status ===="
+  echo "Database service: $db_status"
+  echo "Redis service: $redis_status"
+  echo "Web service (Nginx): $nginx_status"
+  echo "PM2 process '$APP_NAME': $pm2_status"
+  print_access_info
+}
+
 # Always operate from the application directory
 cd "$APP_DIR" 2>/dev/null || {
   echo "Application directory $APP_DIR not found"
@@ -14,17 +49,17 @@ cd "$APP_DIR" 2>/dev/null || {
 case "$COMMAND" in
   start)
     pm2 start ecosystem.config.js
-    pm2 status "$APP_NAME"
+    print_service_status
     ;;
   stop)
     pm2 stop "$APP_NAME"
     ;;
   restart)
     pm2 restart "$APP_NAME"
-    pm2 status "$APP_NAME"
+    print_service_status
     ;;
   status)
-    pm2 status "$APP_NAME"
+    print_service_status
     ;;
   update)
     git pull && pnpm install && pm2 restart "$APP_NAME"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ This command runs from `/var/www/accounting-system`, so you can invoke `NexAccou
   NexAccount Status
   ```
 
+Each of the `Start`, `Restart` and `Status` commands prints the current
+service state along with the URLs for accessing the application.
+
 - **Update** the application
 
   ```bash

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -131,3 +131,11 @@ fi
 echo "PM2 process '$APP_NAME': $PM2_STATUS"
 echo "Use the 'NexAccount' command to manage the application (Start|Stop|Restart|Status|Update|Delete)."
 echo "If any service is not active you may need to restart the server."
+
+# Display how to access the application
+IP_ADDRESS=$(hostname -I | awk '{print $1}')
+echo "\nAccess the application via:"
+echo " - HTTP:  http://$DOMAIN (IP: $IP_ADDRESS, port 80)"
+if [ "$USE_SSL" = "true" ]; then
+    echo " - HTTPS: https://$DOMAIN (IP: $IP_ADDRESS, port 443)"
+fi


### PR DESCRIPTION
## Summary
- display service status and access details at the end of `setup-all.sh`
- make `NexAccount` show service status and access info on `Start`, `Restart` and `Status`
- document enhanced `NexAccount` output in the README

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6846ebb71fdc8330856399ffe6e74df8