### PR TITLE
Add log command to NexAccount CLI

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -40,6 +40,27 @@ print_service_status() {
   print_access_info
 }
 
+display_logs() {
+  echo "==== Latest Logs ===="
+  echo "-- Nginx --"
+  sudo tail -n 20 /var/log/nginx/error.log 2>/dev/null || true
+
+  echo "\n-- PostgreSQL --"
+  local pg_log
+  pg_log=$(ls /var/log/postgresql/postgresql-*.log 2>/dev/null | sort | tail -n 1)
+  [ -n "$pg_log" ] && sudo tail -n 20 "$pg_log" 2>/dev/null || true
+
+  echo "\n-- UFW Firewall --"
+  sudo tail -n 20 /var/log/ufw.log 2>/dev/null || true
+
+  echo "\n-- Fail2Ban --"
+  sudo tail -n 20 /var/log/fail2ban.log 2>/dev/null || true
+
+  echo "\n-- PM2/Application --"
+  tail -n 20 ~/.pm2/logs/${APP_NAME}-out.log 2>/dev/null || true
+  tail -n 20 ~/.pm2/logs/${APP_NAME}-error.log 2>/dev/null || true
+}
+
 # Always operate from the application directory
 cd "$APP_DIR" 2>/dev/null || {
   echo "Application directory $APP_DIR not found"
@@ -67,8 +88,11 @@ case "$COMMAND" in
   delete)
     pm2 delete "$APP_NAME"
     ;;
+  log|logs)
+    display_logs
+    ;;
   *)
-    echo "Usage: NexAccount {Start|Stop|Restart|Status|Update|Delete}"
+    echo "Usage: NexAccount {Start|Stop|Restart|Status|Update|Delete|Log}"
     exit 1
     ;;
  esac

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ service state along with the URLs for accessing the application.
   NexAccount Delete
   ```
 
+- **View service logs**
+
+  ```bash
+  NexAccount Log
+  ```
+
 ### Accessing the application
 
 After running `setup-all.sh`, the install summary shows whether HTTPS was enabled. By default the site is available at:


### PR DESCRIPTION
## Summary
- extend `NexAccount` to show logs from nginx, PostgreSQL, ufw, fail2ban and PM2
- describe the new command in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ec9fe944833089634191a1f32429