### PR TITLE
Expand firewall ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ Logs for the major components can be found in the following locations:
 
 ### Firewall
 
-`setup-firewall.sh` configures UFW to open ports 22, 80, 443 and 3000 so the project operates correctly.
+`setup-firewall.sh` configures UFW to open ports 22, 80, 443, 3000, 5432, 6379, 9090 and 9100 so the project operates correctly.
 

--- a/setup-firewall.sh
+++ b/setup-firewall.sh
@@ -12,6 +12,10 @@ sudo ufw allow 22
 sudo ufw allow 80
 sudo ufw allow 443
 sudo ufw allow 3000
+sudo ufw allow 5432
+sudo ufw allow 6379
+sudo ufw allow 9090
+sudo ufw allow 9100
 
 # Enable the firewall if not already enabled
 STATUS=$(sudo ufw status | head -n1)


### PR DESCRIPTION
## Summary
- update firewall script to open database, cache, and monitoring ports
- document the expanded list of firewall ports in README

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846eeb934b483309a8e48dfaf2a6f3f