### PR TITLE
Enhance NexAccount help output

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -150,6 +150,29 @@ EOL
   sudo nginx -t && sudo systemctl restart nginx
 }
 
+# Display usage information
+show_help() {
+  cat <<EOF
+NexAccount - manage the accounting system
+
+Usage: NexAccount <command>
+
+Commands:
+  Start      Start the application and show status information
+  Stop       Stop the application
+  Restart    Restart the application and show status information
+  Status     Display the current service status and access URLs
+  Update     Pull latest code, install dependencies and restart
+  DbUpdate   Verify database structure and update related files
+  Firewall   Ensure UFW firewall is configured and running
+  Webserver  Ensure Nginx is configured and running
+  Delete     Remove the PM2 process
+  Log        Display recent service logs
+  Help       Show this help message
+
+EOF
+}
+
 # Always operate from the application directory
 cd "$APP_DIR" 2>/dev/null || {
   echo "Application directory $APP_DIR not found"
@@ -218,8 +241,13 @@ case "$COMMAND" in
   log|logs)
     display_logs
     ;;
+  help|-h|--help|"")
+    show_help
+    ;;
   *)
-    echo "Usage: NexAccount {Start|Stop|Restart|Status|Update|DbUpdate|Firewall|Webserver|Delete|Log}"
+    echo "Unknown command: $1"
+    echo
+    show_help
     exit 1
     ;;
 esac

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ For production deployments the application can be managed using **PM2**. After r
 The `setup-all.sh` script also installs a helper command named `NexAccount` in `/usr/local/bin` to make management easier.
 This command runs from `/var/www/accounting-system`, so you can invoke `NexAccount` anywhere on the system.
 
+Run `NexAccount help` to display a summary of all available commands.
+
 - **Start** the application
 
   ```bash
@@ -124,6 +126,12 @@ service state along with the URLs for accessing the application.
 
   ```bash
   NexAccount Log
+  ```
+
+- **Help**
+
+  ```bash
+  NexAccount help
   ```
 
 ### Accessing the application


### PR DESCRIPTION
## Summary
- add a `show_help` function that provides detailed command descriptions
- display help when `help`, `-h`, `--help` or no command is given
- improve unknown command handling
- document the help option in the README

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f27c124c8330a901eabf16a4f2d4