### PR TITLE
Implement cleanup script after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ export REPO_URL=https://github.com/naturae-syria/Accounting.git
 sudo bash install-debian.sh
 ```
 
+Temporary files generated during installation are automatically removed by
+`cleanup-temp.sh` which runs at the end of the installer.
+
 ## Manual setup
 
 1. Install Node.js, pnpm, PostgreSQL and Redis on your machine.

--- a/cleanup-temp.sh
+++ b/cleanup-temp.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Remove temporary files created during installation
+# Without touching essential configuration or data
+
+set -e
+
+# Clean apt cache
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get clean
+  sudo rm -rf /var/lib/apt/lists/*
+fi
+
+# Prune pnpm store if pnpm is available
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm store prune || true
+fi
+
+# Remove typical debug logs
+rm -f .pnpm-debug.log* npm-debug.log* yarn-debug.log* yarn-error.log*
+
+# Delete leftover *.tmp files and 'tmp' directories within project
+find . -path ./node_modules -prune -o -type f -name '*.tmp' -delete
+find . -path ./node_modules -prune -o -type d -name 'tmp' -exec rm -rf {} +
+
+echo "Temporary files cleaned up."

--- a/install-all.sh
+++ b/install-all.sh
@@ -691,3 +691,6 @@ to monitor container status and resource usage
 EOF
 
 print_message "$YELLOW" "Contact information saved to 'connection-info.txt'"
+
+# Remove temporary files created during installation
+./cleanup-temp.sh

--- a/install-debian.sh
+++ b/install-debian.sh
@@ -55,6 +55,9 @@ cd "$APP_DIR"
 export DB_USER DB_NAME DB_PASSWORD DB_HOST DB_PORT
 sudo -E bash setup-all.sh
 
+# Remove temporary files created during installation
+sudo bash cleanup-temp.sh
+
 echo "Installation complete."
 echo "Database user: $DB_USER"
 echo "Database name: $DB_NAME"

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -139,3 +139,7 @@ echo " - HTTP:  http://$DOMAIN (IP: $IP_ADDRESS, port 80)"
 if [ "$USE_SSL" = "true" ]; then
     echo " - HTTPS: https://$DOMAIN (IP: $IP_ADDRESS, port 443)"
 fi
+
+# Remove temporary files created during installation
+echo "Cleaning up temporary files..."
+./cleanup-temp.sh


### PR DESCRIPTION
## Summary
- add `cleanup-temp.sh` to remove caches and temp files
- call cleanup script at the end of `setup-all.sh`, `install-debian.sh` and `install-all.sh`
- document cleanup behavior in README

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f37d87848330839da800932e7564