### PR TITLE
Fix nginx default site

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 80 default_server;
     server_name _;
 
     location / {

--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -21,8 +21,9 @@ fi
 echo "Creating Nginx configuration file..."
 sudo tee /etc/nginx/sites-available/$APP_NAME > /dev/null << EOL
 server {
-    listen 80;
-    server_name $DOMAIN;
+    # Handle requests on port 80 for any host by default
+    listen 80 default_server;
+    server_name $DOMAIN _;
     
     location / {
         proxy_pass http://localhost:3000;


### PR DESCRIPTION
## Summary
- serve the app as the default nginx site
- allow any host in setup script

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ff747c3c8330aa50945c4c46ac1d