### PR TITLE
Prevent automatic dependency installs

### DIFF
--- a/init-db.sh
+++ b/init-db.sh
@@ -26,7 +26,8 @@ done
 # Initialize the database
 echo "Initializing the database..."
 if [ ! -x node_modules/.bin/ts-node ]; then
-    echo "Node dependencies not installed. Attempting to install..."
-    pnpm install || true
+    echo "Node dependencies not installed."
+    echo "Please run 'pnpm install' before executing this script."
+    exit 1
 fi
 pnpm run init-db

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -47,8 +47,9 @@ export DB_PORT=$DB_PORT
 
 # تشغيل سكريبت تهيئة قاعدة البيانات
 if [ ! -x node_modules/.bin/ts-node ]; then
-    echo "Node dependencies not installed. Attempting to install..."
-    pnpm install || true
+    echo "Node dependencies not installed."
+    echo "Please run 'pnpm install' before executing this script."
+    exit 1
 fi
 pnpm run init-db
 


### PR DESCRIPTION
## Summary
- avoid running `pnpm install` automatically in `init-db.sh` and `setup-db.sh`
- instruct users to run `pnpm install` manually when dependencies are missing

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68471757963c8330b309dbbe69604bb5