### PR TITLE
Fix date-fns peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "date-fns": "4.1.0",
+    "date-fns": "^2.30.0",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",


### PR DESCRIPTION
## Summary
- fix react-day-picker peer dependency warning by downgrading `date-fns` to `^2.30.0`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471c4b156c833089ba82df7974c681