### PR TITLE
Fix missing cookie module

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
+    "cookie": "^0.5.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `cookie` dependency for authentication routes

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471dac28a48330acb539a2388690ba