### PR TITLE
Update ESLint to latest version

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -530,7 +530,7 @@ cat > package.json << 'EOF'
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
-    "eslint": "8.44.0",
+    "eslint": "^9.1.0",
     "eslint-config-next": "13.4.9",
     "postcss": "8.4.25",
     "tailwindcss": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tailwindcss": "3.4.17",
     "typescript": "5.8.3",
     "ts-node": "10.9.2",
-    "eslint": "8.57.1",
+    "eslint": "^9.1.0",
     "eslint-config-next": "14.2.29"
   }
 }


### PR DESCRIPTION
## Summary
- bump ESLint to ^9.1.0 in package.json
- update install script with the new ESLint version

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847219099a48330ac9b5326ecd2e03c