### PR TITLE
Fix missing deps warnings

### DIFF
--- a/components/distribution-centers.tsx
+++ b/components/distribution-centers.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -50,11 +50,7 @@ export default function DistributionCenters() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadCenters()
-  }, [])
-
-  const loadCenters = () => {
+  const loadCenters = useCallback(() => {
     try {
       const centersData = getDistributionCenters()
       console.log("Loaded centers:", centersData)
@@ -67,7 +63,12 @@ export default function DistributionCenters() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadCenters()
+  }, [loadCenters])
+
 
   const handleAddCenter = () => {
     try {

--- a/components/inventory.tsx
+++ b/components/inventory.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -45,11 +45,7 @@ export default function Inventory() {
   const [productInventoryReport, setProductInventoryReport] = useState<any[]>([])
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  const loadData = () => {
+  const loadData = useCallback(() => {
     try {
       const productsData = getProducts()
       const centersData = getDistributionCenters()
@@ -66,7 +62,11 @@ export default function Inventory() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleAdjustInventory = () => {
     if (!currentProduct || !adjustmentCenterId) return

--- a/components/products.tsx
+++ b/components/products.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -37,11 +37,7 @@ export default function Products() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadProducts()
-  }, [])
-
-  const loadProducts = () => {
+  const loadProducts = useCallback(() => {
     try {
       const productsData = getProducts()
       console.log("Loaded products:", productsData)
@@ -54,7 +50,11 @@ export default function Products() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadProducts()
+  }, [loadProducts])
 
   const handleAddProduct = () => {
     try {

--- a/components/sales.tsx
+++ b/components/sales.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -59,11 +59,7 @@ export default function Sales() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  const loadData = () => {
+  const loadData = useCallback(() => {
     try {
       const productsData = getProducts()
       const centersData = getDistributionCenters()
@@ -80,7 +76,11 @@ export default function Sales() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleAddSale = () => {
     try {


### PR DESCRIPTION
## Summary
- fix React exhaustive deps warnings by wrapping loader functions in `useCallback` and adding them to the dependency arrays

## Testing
- `pnpm test`
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684721b9976883308d920cfa31023179