### PR TITLE
Fix metrics export causing route compilation error

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,22 +1,6 @@
 import { NextResponse } from "next/server"
-import { register, collectDefaultMetrics, Counter, Histogram } from "prom-client"
-
-// جمع المقاييس الافتراضية
-collectDefaultMetrics()
-
-// إنشاء مقاييس مخصصة
-const httpRequestsTotal = new Counter({
-  name: "http_requests_total",
-  help: "Total number of HTTP requests",
-  labelNames: ["method", "route", "status"],
-})
-
-const httpRequestDuration = new Histogram({
-  name: "http_request_duration_seconds",
-  help: "Duration of HTTP requests in seconds",
-  labelNames: ["method", "route", "status"],
-  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
-})
+import { register } from "prom-client"
+import { httpRequestsTotal, httpRequestDuration } from "@/lib/metrics"
 
 export async function GET() {
   try {
@@ -32,6 +16,3 @@ export async function GET() {
     return NextResponse.json({ error: "Error collecting metrics" }, { status: 500 })
   }
 }
-
-// تصدير المقاييس لاستخدامها في أماكن أخرى
-export { httpRequestsTotal, httpRequestDuration }

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,17 @@
+import { register, collectDefaultMetrics, Counter, Histogram } from "prom-client"
+
+// Collect default metrics
+collectDefaultMetrics()
+
+export const httpRequestsTotal = new Counter({
+  name: "http_requests_total",
+  help: "Total number of HTTP requests",
+  labelNames: ["method", "route", "status"],
+})
+
+export const httpRequestDuration = new Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status"],
+  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
+})


### PR DESCRIPTION
## Summary
- move metric definitions to `lib/metrics.ts`
- update metrics API route to import metrics without exporting them

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684721e07fcc83309bc7883a52401443