### PR TITLE
Align eslint-config-next version in install script

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -530,8 +530,8 @@ cat > package.json << 'EOF'
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
-    "eslint": "^9.1.0",
-    "eslint-config-next": "13.4.9",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.2.29",
     "postcss": "8.4.25",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.6"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tailwindcss": "3.4.17",
     "typescript": "5.8.3",
     "ts-node": "10.9.2",
-    "eslint": "^9.1.0",
+    "eslint": "^8.56.0",
     "eslint-config-next": "14.2.29"
   }
 }


### PR DESCRIPTION
## Summary
- sync `eslint-config-next` in `install-all.sh` with `package.json`
- ensure `next lint` uses ESLint v8 to avoid "Invalid Options" errors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472670f94c8330b74648f0e81b72f0