### PR TITLE
Fix NextResponse import

### DIFF
--- a/app/api/custom-reports/[id]/route.ts
+++ b/app/api/custom-reports/[id]/route.ts
@@ -1,4 +1,4 @@
-import { type NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { deleteCustomReport } from "@/lib/db"
 
 export async function DELETE(_request: Request, { params }: { params: { id: string } }) {


### PR DESCRIPTION
## Summary
- correct NextResponse import type in custom reports route

## Testing
- `npm test`
- `npx next lint` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6847309ee1e0833093542709bc5b6d32