### PR TITLE
Add pg_isready loop to run-docker

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -6,9 +6,12 @@ chmod +x init-db.sh
 # Build and start the containers
 docker-compose up -d
 
-# Wait for services to be ready
-echo "Waiting for services to be ready..."
-sleep 10
+# Wait for the database service to be ready
+echo "Waiting for the database to be ready..."
+until docker-compose exec db pg_isready >/dev/null 2>&1; do
+  echo "Database not ready yet... waiting 2 seconds"
+  sleep 2
+done
 
 # Initialize the database
 docker-compose exec app ./init-db.sh


### PR DESCRIPTION
## Summary
- wait for the Postgres service before initializing the database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68473b98beac83309e44f9d1474ec6db