### PR TITLE
Add DB healthcheck and env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,14 @@
+# Default values are for local development only. Replace them in production.
+# In production, store secrets securely (e.g. via system environment variables
+# or a secrets manager) rather than committing them to version control.
+DB_USER=postgres
+DB_HOST=db
+DB_NAME=accounting_system
+DB_PASSWORD=postgres_password
+DB_PORT=5432
+REDIS_URL=redis://localhost:6379
+# Credentials for the built-in admin user
+ADMIN_USER=admin
+ADMIN_PASS=admin123
+# Uncomment to serve the app under a subpath (e.g. for GitHub Pages)
+# NEXT_BASE_PATH=/accounting-distribution-system

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env
+# .env
 !.env.example
 
 # vercel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,12 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
     environment:
       - NODE_ENV=production
-      - DB_USER=postgres
-      - DB_HOST=db
-      - DB_NAME=accounting_system
-      - DB_PASSWORD=postgres_password
-      - DB_PORT=5432
       # إذا كنت تريد استخدام Redis، قم بإلغاء التعليق على السطر التالي
       # - REDIS_URL=redis://redis:6379
     networks:
@@ -27,10 +25,18 @@ services:
     restart: always
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - .env
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres_password
-      - POSTGRES_DB=accounting_system
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $DB_USER -d $DB_NAME"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
## Summary
- add `.env` based on `.env.example`
- reference `.env` via `env_file` in docker-compose
- map postgres variables to application variables
- wait for DB readiness using healthcheck and update `depends_on`
- track `.env`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68473c898c9c8330a0fd77dc8a5d9cbc