### PR TITLE
Fix error handling and remove font binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+public/fonts/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ sudo bash install-debian.sh
 Temporary files generated during installation are automatically removed by
 `cleanup-temp.sh` which runs at the end of the installer.
 
+The installer also downloads the **Tajawal** font using `download-fonts.sh` so
+the build can run offline. Font files are not stored in the repository and will
+be placed under `public/fonts/Tajawal` after running the script.
+
 ## Manual setup
 
 1. Install Node.js, pnpm, PostgreSQL and Redis on your machine.
@@ -42,6 +46,13 @@ Temporary files generated during installation are automatically removed by
 
 ```bash
 pnpm install
+```
+
+After installing dependencies, run `download-fonts.sh` to fetch the Tajawal font
+files locally. The fonts will be added to `public/fonts/Tajawal`:
+
+```bash
+./download-fonts.sh
 ```
 
 3. Copy `.env.example` to `.env` (or export the variables in your shell) and update the values as needed:

--- a/app/api/init-db/route.ts
+++ b/app/api/init-db/route.ts
@@ -16,10 +16,11 @@ export async function GET() {
     await seedDatabase()
 
     return NextResponse.json({ success: true, message: "تم تهيئة قاعدة البيانات بنجاح" })
-  } catch (error) {
+  } catch (error: unknown) {
     console.error("خطأ في تهيئة قاعدة البيانات:", error)
+    const message = error instanceof Error ? error.message : String(error)
     return NextResponse.json(
-      { success: false, message: "حدث خطأ أثناء تهيئة قاعدة البيانات", error: error.message },
+      { success: false, message: "حدث خطأ أثناء تهيئة قاعدة البيانات", error: message },
       { status: 500 },
     )
   }

--- a/app/api/sales/route.ts
+++ b/app/api/sales/route.ts
@@ -18,9 +18,10 @@ export async function POST(request: NextRequest) {
     const sale = await request.json()
     const newSale = await addSale(sale)
     return NextResponse.json(newSale, { status: 201 })
-  } catch (error) {
+  } catch (error: unknown) {
     console.error("خطأ في إضافة عملية البيع:", error)
-    return NextResponse.json({ error: "حدث خطأ أثناء إضافة عملية البيع", message: error.message }, { status: 500 })
+    const message = error instanceof Error ? error.message : String(error)
+    return NextResponse.json({ error: "حدث خطأ أثناء إضافة عملية البيع", message }, { status: 500 })
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,13 +3,18 @@ import type { Metadata } from "next"
 import "./globals.css"
 
 // استيراد خط Tajawal باستخدام next/font/google
-import { Tajawal } from "next/font/google"
+import localFont from "next/font/local"
 import { APP_VERSION } from "@/lib/version"
 
 // تكوين خط Tajawal
-const tajawal = Tajawal({
-  subsets: ["arabic"],
-  weight: ["300", "400", "500", "700", "800"],
+const tajawal = localFont({
+  src: [
+    { path: "../public/fonts/Tajawal/Tajawal-Light.woff2", weight: "300", style: "normal" },
+    { path: "../public/fonts/Tajawal/Tajawal-Regular.woff2", weight: "400", style: "normal" },
+    { path: "../public/fonts/Tajawal/Tajawal-Medium.woff2", weight: "500", style: "normal" },
+    { path: "../public/fonts/Tajawal/Tajawal-Bold.woff2", weight: "700", style: "normal" },
+    { path: "../public/fonts/Tajawal/Tajawal-ExtraBold.woff2", weight: "800", style: "normal" },
+  ],
   variable: "--font-tajawal",
   display: "swap",
 })

--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+command -v woff2_compress >/dev/null 2>&1 || {
+  echo "woff2_compress not found. Installing woff2 package..."
+  sudo apt-get update -y >/dev/null
+  sudo apt-get install -y woff2 >/dev/null
+}
+FONT_DIR="public/fonts/Tajawal"
+mkdir -p "$FONT_DIR"
+BASE_URL="https://raw.githubusercontent.com/google/fonts/main/ofl/tajawal"
+# Array of weights to download: Light(300) Regular(400) Medium(500) Bold(700) ExtraBold(800)
+declare -A FILES=( [300]=Tajawal-Light.ttf [400]=Tajawal-Regular.ttf [500]=Tajawal-Medium.ttf [700]=Tajawal-Bold.ttf [800]=Tajawal-ExtraBold.ttf )
+for weight in "${!FILES[@]}"; do
+  file="${FILES[$weight]}"
+  curl -fsSL "$BASE_URL/$file" -o "$FONT_DIR/$file"
+  woff2_compress "$FONT_DIR/$file"
+  rm "$FONT_DIR/$file"
+done

--- a/install-all.sh
+++ b/install-all.sh
@@ -233,6 +233,7 @@ EOF
 # إنشاء مجلد للتطبيق
 mkdir -p app
 mkdir -p public
+./download-fonts.sh
 mkdir -p nginx/conf.d
 mkdir -p nginx/ssl
 mkdir -p init-scripts


### PR DESCRIPTION
## Summary
- handle `unknown` errors in `init-db` and `sales` routes
- use local Tajawal fonts
- remove binary font files from the repo and ignore the font directory
- document running `download-fonts.sh` since fonts aren't stored in git

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Next.js build stuck in container)*

------
https://chatgpt.com/codex/tasks/task_e_68474491f7fc8330941d2e57bb526ec9