### PR TITLE
Fix metrics route imports

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,30 +1,13 @@
 import { NextResponse } from "next/server"
-import { register, collectDefaultMetrics, Counter, Histogram } from "prom-client"
-
-// جمع المقاييس الافتراضية
-collectDefaultMetrics()
-
-// إنشاء مقاييس مخصصة
-const httpRequestsTotal = new Counter({
-  name: "http_requests_total",
-  help: "Total number of HTTP requests",
-  labelNames: ["method", "route", "status"],
-})
-
-const httpRequestDuration = new Histogram({
-  name: "http_request_duration_seconds",
-  help: "Duration of HTTP requests in seconds",
-  labelNames: ["method", "route", "status"],
-  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
-})
+import { getMetrics, metricsContentType } from "@/lib/metrics"
 
 export async function GET() {
   try {
     // جمع المقاييس وإرجاعها
-    const metrics = await register.metrics()
+    const metrics = await getMetrics()
     return new NextResponse(metrics, {
       headers: {
-        "Content-Type": register.contentType,
+        "Content-Type": metricsContentType,
       },
     })
   } catch (error) {
@@ -34,4 +17,4 @@ export async function GET() {
 }
 
 // تصدير المقاييس لاستخدامها في أماكن أخرى
-export { httpRequestsTotal, httpRequestDuration }
+// Exported metrics are imported from '@/lib/metrics'

--- a/components/distribution-centers.tsx
+++ b/components/distribution-centers.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -50,11 +50,7 @@ export default function DistributionCenters() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadCenters()
-  }, [])
-
-  const loadCenters = () => {
+  const loadCenters = useCallback(() => {
     try {
       const centersData = getDistributionCenters()
       console.log("Loaded centers:", centersData)
@@ -67,7 +63,11 @@ export default function DistributionCenters() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadCenters()
+  }, [loadCenters])
 
   const handleAddCenter = () => {
     try {

--- a/components/inventory.tsx
+++ b/components/inventory.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -45,11 +45,7 @@ export default function Inventory() {
   const [productInventoryReport, setProductInventoryReport] = useState<any[]>([])
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  const loadData = () => {
+  const loadData = useCallback(() => {
     try {
       const productsData = getProducts()
       const centersData = getDistributionCenters()
@@ -66,7 +62,11 @@ export default function Inventory() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleAdjustInventory = () => {
     if (!currentProduct || !adjustmentCenterId) return

--- a/components/products.tsx
+++ b/components/products.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -37,11 +37,7 @@ export default function Products() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadProducts()
-  }, [])
-
-  const loadProducts = () => {
+  const loadProducts = useCallback(() => {
     try {
       const productsData = getProducts()
       console.log("Loaded products:", productsData)
@@ -54,7 +50,11 @@ export default function Products() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadProducts()
+  }, [loadProducts])
 
   const handleAddProduct = () => {
     try {

--- a/components/sales.tsx
+++ b/components/sales.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -59,11 +59,7 @@ export default function Sales() {
   })
   const { toast } = useToast()
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  const loadData = () => {
+  const loadData = useCallback(() => {
     try {
       const productsData = getProducts()
       const centersData = getDistributionCenters()
@@ -80,7 +76,11 @@ export default function Sales() {
         variant: "destructive",
       })
     }
-  }
+  }, [toast])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleAddSale = () => {
     try {

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,23 @@
+import { register, collectDefaultMetrics, Counter, Histogram } from 'prom-client'
+
+// Collect default metrics
+collectDefaultMetrics()
+
+export const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'route', 'status'],
+})
+
+export const httpRequestDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'Duration of HTTP requests in seconds',
+  labelNames: ['method', 'route', 'status'],
+  buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10],
+})
+
+export async function getMetrics() {
+  return register.metrics()
+}
+
+export const metricsContentType = register.contentType


### PR DESCRIPTION
## Summary
- remove unused metric imports from API route

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684751799aa083308858ee248991d2c1