### PR TITLE
Fix missing Tajawal font

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ sudo bash install-debian.sh
 Temporary files generated during installation are automatically removed by
 `cleanup-temp.sh` which runs at the end of the installer.
 
-The installer also downloads the **Tajawal** font using `download-fonts.sh` so
-the build can run offline. Font files are not stored in the repository and will
-be placed under `public/fonts/Tajawal` after running the script.
+The installer also downloads the **Tajawal** font so the build can run offline.
+Font files are not stored in the repository and will be placed under
+`public/fonts/Tajawal` after running the script.
 
 ## Manual setup
 
@@ -48,12 +48,8 @@ be placed under `public/fonts/Tajawal` after running the script.
 pnpm install
 ```
 
-After installing dependencies, run `download-fonts.sh` to fetch the Tajawal font
-files locally. The fonts will be added to `public/fonts/Tajawal`:
-
-```bash
-./download-fonts.sh
-```
+The Tajawal font files will be downloaded automatically during installation
+and placed under `public/fonts/Tajawal`.
 
 3. Copy `.env.example` to `.env` (or export the variables in your shell) and update the values as needed:
 

--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 command -v woff2_compress >/dev/null 2>&1 || {
   echo "woff2_compress not found. Installing woff2 package..."
   sudo apt-get update -y >/dev/null
@@ -12,7 +13,10 @@ BASE_URL="https://raw.githubusercontent.com/google/fonts/main/ofl/tajawal"
 declare -A FILES=( [300]=Tajawal-Light.ttf [400]=Tajawal-Regular.ttf [500]=Tajawal-Medium.ttf [700]=Tajawal-Bold.ttf [800]=Tajawal-ExtraBold.ttf )
 for weight in "${!FILES[@]}"; do
   file="${FILES[$weight]}"
-  curl -fsSL "$BASE_URL/$file" -o "$FONT_DIR/$file"
-  woff2_compress "$FONT_DIR/$file"
-  rm "$FONT_DIR/$file"
+  target="${file%.ttf}.woff2"
+  if [ ! -f "$FONT_DIR/$target" ]; then
+    curl -fsSL "$BASE_URL/$file" -o "$FONT_DIR/$file"
+    woff2_compress "$FONT_DIR/$file" >/dev/null
+    rm "$FONT_DIR/$file"
+  fi
 done

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "init-db": "ts-node -P tsconfig.init.json ./lib/db.ts && echo 'Database ready'",
-    "test": "node --test"
+    "test": "node --test",
+    "postinstall": "./download-fonts.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- install Tajawal fonts automatically
- avoid re-downloading existing fonts
- clarify in README that fonts are downloaded during install

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_684758b8729083308e2f7666940a02f8