### PR TITLE
Fix NextResponse import in API route

### DIFF
--- a/app/api/custom-reports/[id]/route.ts
+++ b/app/api/custom-reports/[id]/route.ts
@@ -1,4 +1,4 @@
-import { type NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { deleteCustomReport } from "@/lib/db"
 
 export async function DELETE(_request: Request, { params }: { params: { id: string } }) {


### PR DESCRIPTION
## Summary
- fix import for `NextResponse` in custom reports DELETE API

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Failed to fetch `Tajawal` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68475bd2d7888330a104f0482a6beb09