### PR TITLE
Add local Tajawal fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+public/fonts/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are running Debian 12 you can use the automated installer:
 sudo bash install-debian.sh
 ```
 
-The script installs all dependencies, clones the repository and runs `setup-all.sh` to configure the system. You can override defaults by exporting variables before running the script, e.g.:
+The script installs all dependencies, clones the repository, downloads the **Tajawal** font using `download-fonts.sh` and runs `setup-all.sh` to configure the system. The font files are fetched from the [Google Fonts GitHub repository](https://github.com/google/fonts/tree/main/ofl/tajawal) by default. You can override the URL by setting the `FONT_BASE_URL` environment variable before running the script. You can also override other defaults by exporting variables, e.g.:
 
 ```bash
 export APP_USER=myuser
@@ -44,7 +44,14 @@ Temporary files generated during installation are automatically removed by
 pnpm install
 ```
 
-3. Copy `.env.example` to `.env` (or export the variables in your shell) and update the values as needed:
+3. Download the Tajawal fonts (from GitHub by default):
+
+```bash
+./download-fonts.sh
+```
+You can set `FONT_BASE_URL` if you want to use an alternate download source.
+
+4. Copy `.env.example` to `.env` (or export the variables in your shell) and update the values as needed:
 
 ```env
 DB_USER=postgres
@@ -55,13 +62,13 @@ DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 ```
 
-4. Initialize the database:
+5. Initialize the database:
 
 ```bash
 pnpm run init-db
 ```
 
-5. Start the development server:
+6. Start the development server:
 
 ```bash
 pnpm dev

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,13 +3,38 @@ import type { Metadata } from "next"
 import "./globals.css"
 
 // استيراد خط Tajawal باستخدام next/font/google
-import { Tajawal } from "next/font/google"
+import localFont from "next/font/local"
 import { APP_VERSION } from "@/lib/version"
 
 // تكوين خط Tajawal
-const tajawal = Tajawal({
-  subsets: ["arabic"],
-  weight: ["300", "400", "500", "700", "800"],
+const tajawal = localFont({
+  src: [
+    {
+      path: "../public/fonts/Tajawal/Tajawal-Light.ttf",
+      weight: "300",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/Tajawal/Tajawal-Regular.ttf",
+      weight: "400",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/Tajawal/Tajawal-Medium.ttf",
+      weight: "500",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/Tajawal/Tajawal-Bold.ttf",
+      weight: "700",
+      style: "normal",
+    },
+    {
+      path: "../public/fonts/Tajawal/Tajawal-ExtraBold.ttf",
+      weight: "800",
+      style: "normal",
+    },
+  ],
   variable: "--font-tajawal",
   display: "swap",
 })

--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+FONT_DIR="public/fonts/Tajawal"
+mkdir -p "$FONT_DIR"
+
+# Base URL can be overridden via FONT_BASE_URL environment variable
+base_url="${FONT_BASE_URL:-https://raw.githubusercontent.com/google/fonts/main/ofl/tajawal}"
+fonts=(
+  Tajawal-Light.ttf
+  Tajawal-Regular.ttf
+  Tajawal-Medium.ttf
+  Tajawal-Bold.ttf
+  Tajawal-ExtraBold.ttf
+)
+
+for font in "${fonts[@]}"; do
+  if [ -f "$FONT_DIR/$font" ]; then
+    echo "$font already exists, skipping download."
+    continue
+  fi
+  echo "Downloading $font..."
+  curl -L -o "$FONT_DIR/$font" "$base_url/$font"
+  echo "Saved $FONT_DIR/$font"
+done
+
+echo "Tajawal fonts downloaded to $FONT_DIR"

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -49,6 +49,14 @@ if [ ! -x node_modules/.bin/ts-node ]; then
     pnpm add -D ts-node || sudo npm install -g ts-node || true
 fi
 
+# Download fonts for offline builds if they are missing
+if [ ! -d public/fonts/Tajawal ]; then
+    echo "Downloading fonts..."
+    ./download-fonts.sh
+else
+    echo "Tajawal fonts already present, skipping download."
+fi
+
 # إعداد قاعدة البيانات
 echo "Setting up the database..."
 ./setup-db.sh


### PR DESCRIPTION
## Summary
- add script to download Tajawal fonts locally
- load local fonts with `next/font/local`
- ignore downloaded fonts in git
- run font download step during system setup
- document font installation in README
- **Improve font download handling**: skip download if fonts already exist and allow overriding URL via `FONT_BASE_URL`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68475456f86c8330a0d216cd70ed4964