### PR TITLE
Fix docker-compose lint warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
## Summary
- remove the obsolete `version` field from `docker-compose.yml`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684763fc115c8330bf9e0d00ab518edb