### PR TITLE
Fix search param type handling in reports

### DIFF
--- a/app/api/reports/center-sales/[id]/route.ts
+++ b/app/api/reports/center-sales/[id]/route.ts
@@ -7,8 +7,8 @@ export async function GET(request: NextRequest, { params }: any) {
   try {
     const id = params.id
     const { searchParams } = request.nextUrl
-    const startDate = searchParams.get("startDate")
-    const endDate = searchParams.get("endDate")
+    const startDate = searchParams.get("startDate") ?? undefined
+    const endDate = searchParams.get("endDate") ?? undefined
 
     const report = await getSalesByCenterReport(id, startDate, endDate)
     return NextResponse.json(report)

--- a/app/api/reports/inventory-log/route.ts
+++ b/app/api/reports/inventory-log/route.ts
@@ -6,8 +6,8 @@ import { getInventoryLog } from "@/lib/db"
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = request.nextUrl
-    const productId = searchParams.get("productId")
-    const centerId = searchParams.get("centerId")
+    const productId = searchParams.get("productId") ?? undefined
+    const centerId = searchParams.get("centerId") ?? undefined
 
     const logs = await getInventoryLog(productId, centerId)
     return NextResponse.json(logs)


### PR DESCRIPTION
## Summary
- fix `center-sales` and `inventory-log` report routes so optional query parameters are typed correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684768447d2c8330a295a56299e226d9