### PR TITLE
Add DATABASE_URL support for DB connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
+# Optionally use DATABASE_URL instead of the above
+DATABASE_URL=
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
 ADMIN_USER=admin

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
+# Alternatively you can use a single connection string
+# DATABASE_URL=postgres://user:password@localhost:5432/accounting_system
 REDIS_URL=redis://localhost:6379
 ```
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,13 +9,15 @@ import type {
 import { env } from "./env"
 
 // إعداد الاتصال بقاعدة البيانات
-export const pool = new Pool({
-  user: env.DB_USER,
-  host: env.DB_HOST,
-  database: env.DB_NAME,
-  password: env.DB_PASSWORD,
-  port: env.DB_PORT,
-})
+export const pool = env.DATABASE_URL
+  ? new Pool({ connectionString: env.DATABASE_URL })
+  : new Pool({
+      user: env.DB_USER,
+      host: env.DB_HOST,
+      database: env.DB_NAME,
+      password: env.DB_PASSWORD,
+      port: env.DB_PORT,
+    })
 
 // التحقق من الاتصال بقاعدة البيانات
 export const testConnection = async () => {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,14 +1,28 @@
 import { z } from 'zod'
 
-const envSchema = z.object({
-  DB_USER: z.string(),
-  DB_HOST: z.string(),
-  DB_NAME: z.string(),
-  DB_PASSWORD: z.string(),
-  DB_PORT: z.preprocess((v) => Number(v), z.number().int()),
-  REDIS_URL: z.string().url().optional(),
-  ADMIN_USER: z.string().default('admin'),
-  ADMIN_PASS: z.string().default('admin123'),
-})
+const envSchema = z
+  .object({
+    DB_USER: z.string().optional(),
+    DB_HOST: z.string().optional(),
+    DB_NAME: z.string().optional(),
+    DB_PASSWORD: z.string().optional(),
+    DB_PORT: z.preprocess((v) => Number(v), z.number().int()).optional(),
+    DATABASE_URL: z.string().url().optional(),
+    REDIS_URL: z.string().url().optional(),
+    ADMIN_USER: z.string().default('admin'),
+    ADMIN_PASS: z.string().default('admin123'),
+  })
+  .refine((data) => {
+    if (data.DATABASE_URL) return true
+    return (
+      data.DB_USER &&
+      data.DB_HOST &&
+      data.DB_NAME &&
+      data.DB_PASSWORD &&
+      typeof data.DB_PORT === 'number'
+    )
+  }, {
+    message: 'Either DATABASE_URL or DB_* variables must be provided',
+  })
 
 export const env = envSchema.parse(process.env)

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -2,9 +2,13 @@ import { strict as assert } from 'assert'
 import { env } from '../lib/env'
 
 test('environment variables are loaded', () => {
-  assert.ok(env.DB_USER)
-  assert.ok(env.DB_HOST)
-  assert.ok(env.DB_NAME)
-  assert.ok(env.DB_PASSWORD)
-  assert.ok(typeof env.DB_PORT === 'number')
+  if (env.DATABASE_URL) {
+    assert.ok(env.DATABASE_URL)
+  } else {
+    assert.ok(env.DB_USER)
+    assert.ok(env.DB_HOST)
+    assert.ok(env.DB_NAME)
+    assert.ok(env.DB_PASSWORD)
+    assert.ok(typeof env.DB_PORT === 'number')
+  }
 })


### PR DESCRIPTION
## Summary
- allow using a DATABASE_URL connection string
- update default environment docs
- adjust environment validation
- update tests for new env logic

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68477ae554508330b2adc995a7da6d62