### PR TITLE
Fix PostgreSQL port conflict in Docker

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ DB_HOST=db
 DB_NAME=accounting_system
 DB_PASSWORD=postgres_password
 DB_PORT=5432
+HOST_DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
 ADMIN_USER=admin

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
+HOST_DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
 ADMIN_USER=admin

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ The repository includes a `docker-compose.yml` file for running the application
 and its dependencies in containers.
 
 1. **Configure environment variables** – copy `.env.example` to `.env` and edit
-   the values for your setup.
+   the values for your setup. If port `5432` is in use on your host machine set
+   `HOST_DB_PORT` to a different free port.
 2. **Build the images**:
 
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       retries: 5
       start_period: 30s
     ports:
-      - "5432:5432"
+      - "${HOST_DB_PORT:-5432}:5432"
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- allow overriding the host's port for PostgreSQL via `HOST_DB_PORT`
- document the new variable in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68477b1c9de48330b3a9e24c59fa698b