### PR TITLE
Allow skipping DB initialization during build

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,8 @@ DB_NAME=accounting_system
 DB_PASSWORD=postgres_password
 DB_PORT=5432
 REDIS_URL=redis://localhost:6379
+# Set to true during builds or tests when a database isn't available
+SKIP_DB=false
 # Credentials for the built-in admin user
 ADMIN_USER=admin
 ADMIN_PASS=admin123

--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,14 @@
 # In production, store secrets securely (e.g. via system environment variables
 # or a secrets manager) rather than committing them to version control.
 DB_USER=postgres
+# Host for the PostgreSQL server. Use `db` when running via docker-compose
 DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
 REDIS_URL=redis://localhost:6379
+# Set to true during builds or tests when a database isn't available
+SKIP_DB=false
 # Credentials for the built-in admin user
 ADMIN_USER=admin
 ADMIN_PASS=admin123

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ DB_PASSWORD=postgres
 DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 ```
+If you are running the stack with Docker, set `DB_HOST=db` so the application
+can reach the database container. For a remote PostgreSQL instance, replace
+`localhost` with the appropriate host name.
+When building without access to a database (for example when exporting static pages), set `SKIP_DB=true` to skip initialization.
 
 5. Initialize the database:
 

--- a/app/api/init-db/route.ts
+++ b/app/api/init-db/route.ts
@@ -1,7 +1,15 @@
 import { NextResponse } from "next/server"
 import { initializeDatabase, seedDatabase, testConnection } from "@/lib/db"
+import { env } from "@/lib/env"
 
 export async function GET() {
+  if (env.SKIP_DB) {
+    console.log("Skipping database initialization: SKIP_DB=true")
+    return NextResponse.json({
+      success: true,
+      message: "Skipping database initialization",
+    })
+  }
   try {
     // اختبار الاتصال بقاعدة البيانات
     const connected = await testConnection()

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -9,6 +9,7 @@ const envSchema = z.object({
   REDIS_URL: z.string().url().optional(),
   ADMIN_USER: z.string().default('admin'),
   ADMIN_PASS: z.string().default('admin123'),
+  SKIP_DB: z.coerce.boolean().optional().default(false),
 })
 
 export const env = envSchema.parse(process.env)

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -7,4 +7,5 @@ test('environment variables are loaded', () => {
   assert.ok(env.DB_NAME)
   assert.ok(env.DB_PASSWORD)
   assert.ok(typeof env.DB_PORT === 'number')
+  assert.equal(typeof env.SKIP_DB, 'boolean')
 })


### PR DESCRIPTION
## Summary
- introduce optional `SKIP_DB` flag in env parsing
- skip database setup in `init-db` route when `SKIP_DB=true`
- document `SKIP_DB` usage in README and env files
- update tests for new environment variable

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68477af855cc8330a5cc147d49d036c3