### PR TITLE
Fix database port conflicts

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ DB_HOST=db
 DB_NAME=accounting_system
 DB_PASSWORD=postgres_password
 DB_PORT=5432
+DB_PORT_HOST=5432
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
 ADMIN_USER=admin

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
+# Host port used when running PostgreSQL via Docker
+DB_PORT_HOST=5432
 # Optionally use DATABASE_URL instead of the above
 DATABASE_URL=
 REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ DB_HOST=localhost
 DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
+# Host port for PostgreSQL when using Docker
+DB_PORT_HOST=5432
 # Alternatively you can use a single connection string
 # DATABASE_URL=postgres://user:password@localhost:5432/accounting_system
 REDIS_URL=redis://localhost:6379
@@ -103,6 +105,8 @@ and its dependencies in containers.
 
 1. **Configure environment variables** – copy `.env.example` to `.env` and edit
    the values for your setup.
+   If port `5432` is already in use on your host, set `DB_PORT_HOST` to a free
+   port number before starting the containers.
 2. **Build the images**:
 
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       retries: 5
       start_period: 30s
     ports:
-      - "5432:5432"
+      - "${DB_PORT_HOST:-5432}:5432"
     networks:
       - app-network
 

--- a/install-all.sh
+++ b/install-all.sh
@@ -101,6 +101,7 @@ print_message "$BLUE" "Creating configuration files..."
 DB_PASSWORD=$(generate_password 16)
 REDIS_PASSWORD=$(generate_password 16)
 APP_SECRET=$(generate_password 32)
+DB_PORT_HOST=5432
 
 # إنشاء ملف Dockerfile
 cat > Dockerfile << 'EOF'
@@ -191,7 +192,7 @@ services:
       - POSTGRES_PASSWORD=$DB_PASSWORD
       - POSTGRES_DB=accounting_system
     ports:
-      - "5432:5432"
+      - "${DB_PORT_HOST}:5432"
     networks:
       - app-network
 
@@ -548,7 +549,7 @@ docker-compose up -d
 
 echo "Application started successfully!"
 echo "You can access the application at: http://localhost:3000"
-echo "You can access the database at: localhost:5432"
+echo "You can access the database at: localhost:$DB_PORT_HOST"
 echo "You can access Redis at: localhost:6379"
 EOF
 
@@ -595,7 +596,7 @@ print_message "$BLUE" "
 
 print_message "$YELLOW" "PostgreSQL database:"
 echo "Host: localhost"
-echo "Port: 5432"
+echo "Port: $DB_PORT_HOST"
 echo "Username: postgres"
 echo "Password: $DB_PASSWORD"
 echo "Database name: accounting_system"
@@ -649,7 +650,7 @@ cat > connection-info.txt << EOF
 
 PostgreSQL database:
 Host: localhost
-Port: 5432
+Port: $DB_PORT_HOST
 Username: postgres
 Password: $DB_PASSWORD
 Database name: accounting_system


### PR DESCRIPTION
## Summary
- add `DB_PORT_HOST` to `.env` and `.env.example`
- map postgres to `${DB_PORT_HOST}` in docker-compose
- document the new variable in README
- explain how to change the port when using Docker
- update install-all script to use `DB_PORT_HOST`

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684828935890833094b1950305b02461