### PR TITLE
Fix build failure due to empty DATABASE_URL

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -23,7 +23,7 @@ function createPool(host: string): Pool {
   })
 }
 
-export let pool = createPool(env.DB_HOST)
+export let pool = createPool(env.DB_HOST!)
 
 // التحقق من الاتصال بقاعدة البيانات
 export const testConnection = async () => {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -7,7 +7,11 @@ const envSchema = z
     DB_NAME: z.string().optional(),
     DB_PASSWORD: z.string().optional(),
     DB_PORT: z.preprocess((v) => Number(v), z.number().int()).optional(),
-    DATABASE_URL: z.string().url().optional(),
+    DATABASE_URL: z
+      .preprocess(
+        (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+        z.string().url().optional()
+      ),
     REDIS_URL: z.string().url().optional(),
     ADMIN_USER: z.string().default('admin'),
     ADMIN_PASS: z.string().default('admin123'),


### PR DESCRIPTION
## Summary
- sanitize `DATABASE_URL` in env parser so empty values are ignored
- mark `DB_HOST` as defined when creating the database pool

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68482e229ba883308fb6143331090951