### PR TITLE
Fix db port conflict automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The repository includes a `docker-compose.yml` file for running the application
 and its dependencies in containers.
 
 1. **Configure environment variables** – copy `.env.example` to `.env` and edit
-   the values for your setup.
-   If port `5432` is already in use on your host, set `DB_PORT_HOST` to a free
-   port number before starting the containers.
+   the values for your setup. The `run-docker.sh` script automatically selects a
+   free host port for PostgreSQL if the configured `DB_PORT_HOST` is in use, so
+   you usually don't need to change it manually.
 2. **Build the images**:
 
    ```bash

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -13,6 +13,31 @@ else
   exit 1
 fi
 
+# Load environment variables from .env if present
+if [ -f .env ]; then
+  # shellcheck disable=SC1091
+  set -a && . ./.env && set +a
+fi
+
+# Determine host port for PostgreSQL (fall back to 5432)
+db_port_host="${DB_PORT_HOST:-5432}"
+
+# If lsof is available, verify the port is free
+if command -v lsof >/dev/null 2>&1; then
+  if lsof -i -P -n | grep -q ":${db_port_host}\s"; then
+    new_port=$db_port_host
+    # Find the next available port
+    while lsof -i -P -n | grep -q ":${new_port}\s"; do
+      new_port=$((new_port + 1))
+    done
+    echo "Port ${db_port_host} is in use, switching to ${new_port}"
+    if [ -w .env ]; then
+      sed -i.bak "s/^DB_PORT_HOST=.*/DB_PORT_HOST=${new_port}/" .env && rm -f .env.bak
+    fi
+    db_port_host=$new_port
+  fi
+fi
+
 # Build and start the containers
 $compose_cmd up -d
 


### PR DESCRIPTION
## Summary
- auto pick free DB port in run-docker script if the default is taken
- mention automatic port selection in the Docker instructions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848364bffd48330b66af6eae7fc3c28