### PR TITLE
Fix type error in inventory centers state

### DIFF
--- a/components/inventory.tsx
+++ b/components/inventory.tsx
@@ -24,7 +24,7 @@ import {
   updateInventory,
   getProductInventoryReport,
 } from "@/lib/data-utils"
-import type { Product, ProductInventory } from "@/lib/types"
+import type { Product, ProductInventory, DistributionCenter } from "@/lib/types"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 
@@ -40,7 +40,7 @@ export default function Inventory() {
   const [adjustmentReason, setAdjustmentReason] = useState("")
   const [adjustmentCenterId, setAdjustmentCenterId] = useState("")
   const [inventory, setInventory] = useState<ProductInventory[]>([])
-  const [centers, setCenters] = useState([])
+  const [centers, setCenters] = useState<DistributionCenter[]>([])
   const [selectedProductForReport, setSelectedProductForReport] = useState<Product | null>(null)
   const [productInventoryReport, setProductInventoryReport] = useState<any[]>([])
   const { toast } = useToast()


### PR DESCRIPTION
## Summary
- fix typing for centers state in `components/inventory.tsx`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848406628d48330bcb9730e1ab10f4e