### PR TITLE
Fix port switching bug in run-docker.sh

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -35,6 +35,7 @@ if command -v lsof >/dev/null 2>&1; then
       sed -i.bak "s/^DB_PORT_HOST=.*/DB_PORT_HOST=${new_port}/" .env && rm -f .env.bak
     fi
     db_port_host=$new_port
+    export DB_PORT_HOST=$new_port
   fi
 fi
 


### PR DESCRIPTION
## Summary
- ensure DB_PORT_HOST is exported after updating `.env`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848427f8b948330b29589b21a911683