### PR TITLE
Add caches polyfill

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 // استيراد خط Tajawal باستخدام next/font/google
 import localFont from "next/font/local"
 import { APP_VERSION } from "@/lib/version"
+import { CachesPolyfill } from "@/components/caches-polyfill"
 
 // تكوين خط Tajawal
 const tajawal = localFont({
@@ -52,7 +53,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ar" dir="rtl">
-      <body className={`${tajawal.variable} font-tajawal`}>{children}</body>
+      <body className={`${tajawal.variable} font-tajawal`}>
+        <CachesPolyfill />
+        {children}
+      </body>
     </html>
   )
 }

--- a/components/caches-polyfill.tsx
+++ b/components/caches-polyfill.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function CachesPolyfill() {
+  useEffect(() => {
+    if (typeof window !== 'undefined' && typeof (window as any).caches === 'undefined') {
+      ;(window as any).caches = {
+        open: () => Promise.reject(new Error('Cache API not available')),
+      }
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- polyfill Cache API in client-side to prevent console errors
- include polyfill in application layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68485f57f3148330ad0b292429113463