### PR TITLE
Fix export for database pool

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -9,7 +9,7 @@ import type {
 import { env } from "./env"
 
 // إعداد الاتصال بقاعدة البيانات
-const pool = new Pool({
+export const pool = new Pool({
   user: env.DB_USER,
   host: env.DB_HOST,
   database: env.DB_NAME,


### PR DESCRIPTION
## Summary
- export `pool` from lib/db so db-cache module compiles

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486be40a24833089720ce3ec5c49d2