### PR TITLE
Fix DB init script env loading

### DIFF
--- a/init-db.sh
+++ b/init-db.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Load environment variables if a .env file is present
+if [ -f .env ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . ./.env
+  set +a
+fi
+
 # Wait until the database is ready
 echo "Waiting for the database to be ready..."
 until node -e "


### PR DESCRIPTION
## Summary
- load `.env` automatically in `init-db.sh` so database scripts don't attempt to connect as the `root` user

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684877f2d3708330b402f6ae9e7c8f38