### PR TITLE
Fix missing init-db.sh in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN pnpm install --frozen-lockfile --prod
 
 # Default environment variables for runtime if none are provided
 COPY --from=builder /app/.env ./
+# Copy database initialization script and make it executable
+COPY --from=builder /app/init-db.sh ./init-db.sh
+RUN chmod +x init-db.sh
 
 # إنشاء مستخدم غير جذري لتشغيل التطبيق
 RUN addgroup --system --gid 1001 nodejs


### PR DESCRIPTION
## Summary
- copy `init-db.sh` into production Docker image and make it executable

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68488041fafc8330b58f689b1bf173c4