### PR TITLE
Fix TypeScript test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "init-db": "ts-node -P tsconfig.init.json ./lib/db.ts && echo 'Database ready'",
-    "test": "node --test"
+    "test": "tsc -p tsconfig.test.json && node --test dist-test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,4 +1,13 @@
+import test from 'node:test'
 import { strict as assert } from 'assert'
+
+// Provide sane defaults to avoid connecting as the root user
+process.env.DB_USER ||= 'postgres'
+process.env.DB_HOST ||= 'localhost'
+process.env.DB_NAME ||= 'accounting_system'
+process.env.DB_PASSWORD ||= 'postgres'
+process.env.DB_PORT ||= '5432'
+
 import { env } from '../lib/env'
 
 test('environment variables are loaded', () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-test",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- enable Node.js tests written in TypeScript
- provide default DB env vars in `env.test.ts`
- use sane defaults so tests don't fall back to the root user

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68488f9d29648330a42498e1b9d1d1dd