### PR TITLE
Fix Grafana repo GPG key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,16 @@ Logs for the major components can be found in the following locations:
 
 `setup-firewall.sh` configures UFW to open ports 22, 80, 443, 3000, 5432, 6379, 9090 and 9100 so the project operates correctly.
 
+### Monitoring setup
+
+Run `setup-monitoring.sh` to install Prometheus and Grafana. If `apt-get update` fails with a `NO_PUBKEY` error, import the Grafana GPG key manually:
+
+```bash
+sudo mkdir -p /usr/share/keyrings
+wget -qO- https://packages.grafana.com/gpg.key | \
+  sudo gpg --dearmor | sudo tee /usr/share/keyrings/grafana-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/grafana-archive-keyring.gpg] https://packages.grafana.com/oss/deb stable main" | \
+  sudo tee /etc/apt/sources.list.d/grafana.list
+sudo apt-get update
+```
+

--- a/setup-monitoring.sh
+++ b/setup-monitoring.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # تثبيت Prometheus
 echo "Installing Prometheus..."
 sudo apt-get update
@@ -18,13 +20,17 @@ fi
 echo "Installing Grafana..."
 sudo apt-get install -y apt-transport-https software-properties-common wget gpg
 
-# Import Grafana GPG key using a system keyring
-sudo mkdir -p /usr/share/keyrings
-wget -qO- https://packages.grafana.com/gpg.key | \
-  sudo gpg --dearmor | sudo tee /usr/share/keyrings/grafana-archive-keyring.gpg > /dev/null
+# Import Grafana GPG key using a system keyring if missing
+GRAFANA_KEYRING=/usr/share/keyrings/grafana-archive-keyring.gpg
+if [ ! -f "$GRAFANA_KEYRING" ]; then
+  echo "Adding Grafana GPG key..."
+  sudo mkdir -p /usr/share/keyrings
+  wget -qO- https://packages.grafana.com/gpg.key | \
+    sudo gpg --dearmor | sudo tee "$GRAFANA_KEYRING" > /dev/null
+fi
 
 # Add the Grafana repository and reference the keyring
-echo "deb [signed-by=/usr/share/keyrings/grafana-archive-keyring.gpg] https://packages.grafana.com/oss/deb stable main" | \
+echo "deb [signed-by=${GRAFANA_KEYRING}] https://packages.grafana.com/oss/deb stable main" | \
   sudo tee /etc/apt/sources.list.d/grafana.list
 
 sudo apt-get update


### PR DESCRIPTION
## Summary
- ensure `setup-monitoring.sh` imports Grafana GPG key if missing
- document how to manually fix the Grafana repository key issue

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684895887b08833080ea45c97c83f9b1