### PR TITLE
Add note about psql role error

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ REDIS_URL=redis://localhost:6379
 pnpm run init-db
 ```
 
+**Note**: If `psql` reports `FATAL: role "root" does not exist`, use the
+`postgres` role to connect:
+
+```bash
+sudo -u postgres psql
+# or
+psql -U postgres
+```
+
 5. Start the development server:
 
 ```bash

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -14,6 +14,9 @@ if ! command -v psql &> /dev/null; then
     sudo apt-get install -y postgresql postgresql-contrib
 fi
 
+# Configure psql to use the postgres role by default
+echo "export PGUSER=postgres" | sudo tee /etc/profile.d/psql-defaults.sh >/dev/null
+
 # Create database and user
 echo "Creating database and user..."
 sudo -u postgres psql << EOF


### PR DESCRIPTION
## Summary
- document how to fix the `role "root" does not exist` error when using psql
- set PGUSER environment variable in `setup-db.sh` so `psql` defaults to the `postgres` role

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848956e2d80833082cd489e3ada4282