### PR TITLE
Fix apt package errors in monitoring setup

### DIFF
--- a/setup-monitoring.sh
+++ b/setup-monitoring.sh
@@ -14,6 +14,8 @@ if [ "$AVAILABLE_SPACE_MB" -lt 700 ]; then
   echo "Low disk space ($AVAILABLE_SPACE_MB MB available). Cleaning apt cache..."
   sudo apt-get clean
   sudo rm -rf /var/lib/apt/lists/*
+  # Recreate apt lists to avoid "package has no installation candidate" errors
+  sudo apt-get update
 fi
 
 # تثبيت Grafana


### PR DESCRIPTION
## Summary
- ensure apt repository indexes are recreated after cleaning in `setup-monitoring.sh`

## Testing
- `pnpm exec next lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849834b9b4883309bc16cd651fd2a98