### PR TITLE
Fix dashboard redirect on login

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,5 @@ ADMIN_USER=admin
 ADMIN_PASS=admin123
 # Uncomment to serve the app under a subpath (e.g. for GitHub Pages)
 # NEXT_BASE_PATH=/accounting-distribution-system
+# When using a base path, also expose it to the client
+# NEXT_PUBLIC_BASE_PATH=/accounting-distribution-system

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ ADMIN_USER=admin
 ADMIN_PASS=admin123
 # Uncomment to serve the app under a subpath (e.g. for GitHub Pages)
 # NEXT_BASE_PATH=/accounting-distribution-system
+# When using a base path, also expose it to the client
+# NEXT_PUBLIC_BASE_PATH=/accounting-distribution-system

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ pnpm start
 ```
 By default the server listens on port 3000. Open `http://localhost:3000` in your browser (or replace `localhost` with your server's IP or domain).
 If you define the `NEXT_BASE_PATH` environment variable when building, append that path to the URL (e.g. `http://localhost:3000$NEXT_BASE_PATH`).
+When a base path is used, set `NEXT_PUBLIC_BASE_PATH` to the same value so client-side API calls can resolve correctly.
 
 ## Development
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -15,6 +15,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const [mounted, setMounted] = useState(false)
   const router = useRouter()
   const { toast } = useToast()
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ""
 
   useEffect(() => {
     // التحقق من حالة تسجيل الدخول
@@ -36,7 +37,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }, [router])
 
   const handleLogout = () => {
-    fetch('/api/auth/logout', { method: 'POST' }).finally(() => {
+    fetch(`${basePath}/api/auth/logout`, { method: 'POST' }).finally(() => {
       router.push('/login')
     })
     toast({

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -17,12 +17,13 @@ export default function Login() {
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
   const { toast } = useToast()
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ""
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
 
-    const res = await fetch('/api/auth/login', {
+    const res = await fetch(`${basePath}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),


### PR DESCRIPTION
## Summary
- include `NEXT_PUBLIC_BASE_PATH` in client login and logout requests
- document the new env var
- add commented example in `.env` and `.env.example`

## Testing
- `npm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684987d3f90c8330b1460442fbec8fa1