### PR TITLE
Implement secure session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ docker-compose down
 
 The dashboard includes a **Custom Reports** tab where you can define your own reports. Choose a report type, enter a name and comma separated columns, then add the report. Reports can be removed from the same tab. They are stored in the database via `/api/custom-reports`.
 
+## Authentication
+
+Authentication uses a simple session cookie. A successful POST to `/api/auth/login` sets a `session` cookie with the `httpOnly`, `secure` and `sameSite=lax` flags enabled. The cookie expires after seven days. Logging out via `/api/auth/logout` clears this cookie using the same options.
+
 ## Managing the application
 
 For production deployments the application can be managed using **PM2**. After running `setup-pm2.sh` an `ecosystem.config.js` file is generated and the app is registered with the name `accounting-system`.

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -7,7 +7,16 @@ export async function POST(request: Request) {
 
   if (username === env.ADMIN_USER && password === env.ADMIN_PASS) {
     const headers = new Headers()
-    headers.append('Set-Cookie', serialize('session', 'auth', { httpOnly: true, path: '/' }))
+    headers.append(
+      'Set-Cookie',
+      serialize('session', 'auth', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 7,
+        path: '/',
+      })
+    )
     return new NextResponse(JSON.stringify({ success: true }), { headers })
   }
 

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -3,6 +3,15 @@ import { serialize } from 'cookie'
 
 export async function POST() {
   const headers = new Headers()
-  headers.append('Set-Cookie', serialize('session', '', { httpOnly: true, path: '/', expires: new Date(0) }))
+  headers.append(
+    'Set-Cookie',
+    serialize('session', '', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: 0,
+      path: '/',
+    })
+  )
   return new NextResponse(null, { headers })
 }


### PR DESCRIPTION
## Summary
- add secure cookie options in login route
- expire cookie in logout route
- document authentication cookie settings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849912cf5f48330b534f73f18244401