### PR TITLE
Clarify secure admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
 # Replace these placeholders with secure values in production.
+# Do NOT use easily guessable values like 'admin' or 'admin123'.
 # These values are hashed when the database is seeded.
 ADMIN_USER=your_admin_user
 ADMIN_PASS=your_admin_password

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ ADMIN_USER=your_admin_user      # set a secure username
 ADMIN_PASS=your_admin_password  # set a strong password
 ```
 
+Avoid using trivial credentials such as `ADMIN_USER=admin` and
+`ADMIN_PASS=admin123`. Always choose unique values when setting up your
+environment.
+
 4. Initialize the database:
 
 ```bash


### PR DESCRIPTION
## Summary
- warn against using `ADMIN_USER=admin` and `ADMIN_PASS=admin123` in README
- add note in `.env.example` to avoid insecure defaults

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684997ace41c8330b359f6bf8d22e63e