### PR TITLE
Fix popper wrapper background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -100,6 +100,7 @@ body {
 /* تعديل نمط نافذة الحوار */
 [data-radix-popper-content-wrapper] {
   z-index: 9999 !important;
+  background-color: var(--background);
 }
 
 .DialogOverlay {


### PR DESCRIPTION
## Summary
- set background color for `[data-radix-popper-content-wrapper]` so it isn't transparent

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68499a1ac71883308b23effaf266427f