### PR TITLE
Switch components to API utilities

### DIFF
--- a/test/api-products.test.ts
+++ b/test/api-products.test.ts
@@ -16,7 +16,7 @@ process.env.ADMIN_USER='admin'
 process.env.ADMIN_PASS='adminpass'
 
 import { initializeDatabase, seedDatabase } from '../lib/db'
-import { GET } from '../app/api/products/route'
+import { GET, POST } from '../app/api/products/route'
 
 await initializeDatabase()
 await seedDatabase()
@@ -25,3 +25,23 @@ const res = await GET()
 const products = await res.json()
 assert.ok(Array.isArray(products))
 assert.ok(products.length > 0)
+
+const newProduct = {
+  name: 'Test',
+  description: 'desc',
+  price: 10,
+  cost: 5,
+  stock: 1,
+  brand: 'b',
+  category: 'c',
+  image: ''
+}
+
+const postRes = await POST(new Request('http://localhost', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(newProduct) }))
+assert.equal(postRes.status, 201)
+const created = await postRes.json()
+assert.ok(created.id)
+
+const resAfter = await GET()
+const productsAfter = await resAfter.json()
+assert.equal(productsAfter.length, products.length + 1)


### PR DESCRIPTION
## Summary
- replace local storage utilities with API-based functions across product, center, sales and inventory pages
- adapt dialogs and handlers to use async database calls
- extend product API test to verify saving via POST

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68499fa1fe18833099a5271f78cf87fe