### PR TITLE
Implement server-side auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The dashboard includes a **Custom Reports** tab where you can define your own re
 
 ## Authentication
 
-Authentication uses a simple session cookie. A successful POST to `/api/auth/login` sets a `session` cookie with the `httpOnly`, `secure` and `sameSite=lax` flags enabled. The cookie expires after seven days. Logging out via `/api/auth/logout` clears this cookie using the same options.
+Authentication uses a simple session cookie. A successful POST to `/api/auth/login` sets a `session` cookie with the `httpOnly`, `secure` and `sameSite=lax` flags enabled. The cookie expires after seven days. Logging out via `/api/auth/logout` clears this cookie using the same options. A GET request to `/api/auth/check` returns `{ valid: true }` when the session cookie is present and valid.
 
 ## Managing the application
 

--- a/app/api/auth/check/route.ts
+++ b/app/api/auth/check/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { parse } from 'cookie'
+
+export async function GET(request: Request) {
+  const cookieHeader = request.headers.get('cookie') || ''
+  const cookies = parse(cookieHeader)
+  const valid = cookies.session === 'auth'
+  return NextResponse.json({ valid })
+}

--- a/components/auth-check.tsx
+++ b/components/auth-check.tsx
@@ -13,13 +13,19 @@ export default function AuthCheck({ children }: AuthCheckProps) {
   const router = useRouter()
 
   useEffect(() => {
-    // التحقق من حالة تسجيل الدخول
-    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true"
-
-    if (!isLoggedIn) {
-      // إذا لم يكن المستخدم مسجل الدخول، انتقل إلى صفحة تسجيل الدخول
-      router.push("/login")
+    const checkSession = async () => {
+      try {
+        const res = await fetch('/api/auth/check')
+        const { valid } = await res.json()
+        if (!valid) {
+          router.push('/login')
+        }
+      } catch {
+        router.push('/login')
+      }
     }
+
+    checkSession()
   }, [router])
 
   return <>{children}</>

--- a/server.ts
+++ b/server.ts
@@ -65,6 +65,11 @@ nextApp.prepare().then(() => {
     res.end()
   })
 
+  app.get('/api/auth/check', (req, res) => {
+    const valid = req.cookies.session === 'auth'
+    res.json({ valid })
+  })
+
   app.all('*', (req, res) => handle(req, res))
 
   const port = Number(process.env.PORT || 3000)

--- a/test/api-auth-check.test.ts
+++ b/test/api-auth-check.test.ts
@@ -1,0 +1,12 @@
+import { strict as assert } from 'assert'
+import { GET } from '../app/api/auth/check/route'
+
+const reqNoCookie = new Request('http://localhost')
+const resNoCookie = await GET(reqNoCookie)
+const dataNoCookie = await resNoCookie.json()
+assert.equal(dataNoCookie.valid, false)
+
+const reqCookie = new Request('http://localhost', { headers: { cookie: 'session=auth' } })
+const resCookie = await GET(reqCookie)
+const dataCookie = await resCookie.json()
+assert.equal(dataCookie.valid, true)


### PR DESCRIPTION
## Summary
- check session cookie with `/api/auth/check`
- validate auth on the client using API call
- expose auth check route on Express server
- document new route
- test API auth check

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a46d83dc83309f4a041913691287