### PR TITLE
Enable Redis caching in product and center APIs

### DIFF
--- a/app/api/centers/[id]/route.ts
+++ b/app/api/centers/[id]/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getDistributionCenterById, updateDistributionCenter, deleteDistributionCenter } from "@/lib/db"
+import { getDistributionCenterById } from "@/lib/db"
+import { updateDistributionCenter, deleteDistributionCenter } from "@/lib/db-cache"
 
 export async function GET(request: NextRequest, { params }: any) {
   try {

--- a/app/api/centers/route.ts
+++ b/app/api/centers/route.ts
@@ -6,7 +6,7 @@ import {
   addDistributionCenter,
   updateDistributionCenter,
   deleteDistributionCenter,
-} from "@/lib/db"
+} from "@/lib/db-cache"
 
 export async function GET() {
   try {

--- a/app/api/products/[id]/route.ts
+++ b/app/api/products/[id]/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { getProductById, updateProduct, deleteProduct } from "@/lib/db"
+import { getProductById } from "@/lib/db"
+import { updateProduct, deleteProduct } from "@/lib/db-cache"
 
 export async function GET(request: NextRequest, { params }: any) {
   try {

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,7 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server"
 
 export const dynamic = "force-dynamic"
-import { getProducts, addProduct, updateProduct, deleteProduct } from "@/lib/db"
+import {
+  getProducts,
+  addProduct,
+  updateProduct,
+  deleteProduct,
+} from "@/lib/db-cache"
 
 export async function GET() {
   try {

--- a/lib/db-cache.ts
+++ b/lib/db-cache.ts
@@ -1,7 +1,7 @@
 // هذا مثال لكيفية تعديل دالة getProducts في lib/db.ts لدعم التخزين المؤقت
 import { getCache, setCache, invalidateCache } from "./redis"
-import type { Product } from "./types"
-import { pool } from "./db"
+import type { Product, DistributionCenter } from "./types"
+import * as db from "./db"
 
 export const getProducts = async (): Promise<Product[]> => {
   try {
@@ -12,23 +12,7 @@ export const getProducts = async (): Promise<Product[]> => {
     }
 
     // إذا لم تكن البيانات موجودة في التخزين المؤقت، استعلم من قاعدة البيانات
-    const result = await pool.query(`
-      SELECT id, name, description, price, cost, stock, brand, category, image
-      FROM products
-      ORDER BY name
-    `)
-
-    const products = result.rows.map((row) => ({
-      id: row.id.toString(),
-      name: row.name,
-      description: row.description || "",
-      price: Number.parseFloat(row.price),
-      cost: Number.parseFloat(row.cost),
-      stock: row.stock,
-      brand: row.brand || "",
-      category: row.category || "",
-      image: row.image || "",
-    }))
+    const products = await db.getProducts()
 
     // تخزين البيانات في التخزين المؤقت
     await setCache("products", JSON.stringify(products), 300) // تخزين لمدة 5 دقائق
@@ -42,39 +26,88 @@ export const getProducts = async (): Promise<Product[]> => {
 
 // تعديل دوال التعديل لإلغاء صلاحية التخزين المؤقت
 export const addProduct = async (product: Omit<Product, "id">): Promise<Product> => {
-  const client = await pool.connect()
   try {
-    const result = await client.query(
-      `
-      INSERT INTO products (name, description, price, cost, stock, brand, category, image)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING id
-    `,
-      [
-        product.name,
-        product.description,
-        product.price,
-        product.cost,
-        product.stock,
-        product.brand,
-        product.category,
-        product.image,
-      ],
-    )
-
-    const productId = result.rows[0].id
-
-    // إلغاء صلاحية التخزين المؤقت للمنتجات
+    const created = await db.addProduct(product)
     await invalidateCache("products")
-
-    return {
-      id: productId.toString(),
-      ...product,
-    }
+    return created
   } catch (error) {
     console.error("خطأ في إضافة المنتج:", error)
     throw error
-  } finally {
-    client.release()
+  }
+}
+
+export const updateProduct = async (id: string, product: Partial<Product>): Promise<Product> => {
+  try {
+    const updated = await db.updateProduct(id, product)
+    await invalidateCache("products")
+    return updated
+  } catch (error) {
+    console.error("خطأ في تحديث المنتج:", error)
+    throw error
+  }
+}
+
+export const deleteProduct = async (id: string): Promise<boolean> => {
+  try {
+    const success = await db.deleteProduct(id)
+    await invalidateCache("products")
+    return success
+  } catch (error) {
+    console.error("خطأ في حذف المنتج:", error)
+    throw error
+  }
+}
+
+export const getDistributionCenters = async (): Promise<DistributionCenter[]> => {
+  try {
+    const cachedData = await getCache("centers")
+    if (cachedData) {
+      return JSON.parse(cachedData)
+    }
+
+    const centers = await db.getDistributionCenters()
+    await setCache("centers", JSON.stringify(centers), 300)
+    return centers
+  } catch (error) {
+    console.error("خطأ في الحصول على مراكز التوزيع:", error)
+    throw error
+  }
+}
+
+export const addDistributionCenter = async (
+  center: Omit<DistributionCenter, "id">,
+): Promise<DistributionCenter> => {
+  try {
+    const created = await db.addDistributionCenter(center)
+    await invalidateCache("centers")
+    return created
+  } catch (error) {
+    console.error("خطأ في إضافة مركز التوزيع:", error)
+    throw error
+  }
+}
+
+export const updateDistributionCenter = async (
+  id: string,
+  center: Partial<DistributionCenter>,
+): Promise<DistributionCenter> => {
+  try {
+    const updated = await db.updateDistributionCenter(id, center)
+    await invalidateCache("centers")
+    return updated
+  } catch (error) {
+    console.error("خطأ في تحديث مركز التوزيع:", error)
+    throw error
+  }
+}
+
+export const deleteDistributionCenter = async (id: string): Promise<boolean> => {
+  try {
+    const success = await db.deleteDistributionCenter(id)
+    await invalidateCache("centers")
+    return success
+  } catch (error) {
+    console.error("خطأ في حذف مركز التوزيع:", error)
+    throw error
   }
 }

--- a/test/api-cache.test.ts
+++ b/test/api-cache.test.ts
@@ -1,0 +1,42 @@
+import { strict as assert } from 'assert'
+import { newDb } from 'pg-mem'
+import pkg from 'pg'
+
+const db = newDb()
+const { Pool } = db.adapters.createPg()
+pkg.Pool = Pool
+
+process.env.DB_USER='user'
+process.env.DB_HOST='localhost'
+process.env.DB_NAME='test'
+process.env.DB_PASSWORD='pass'
+process.env.DB_PORT='5432'
+process.env.ADMIN_USER='admin'
+process.env.ADMIN_PASS='adminpass'
+process.env.REDIS_URL='redis://127.0.0.1:6379'
+
+import { initializeDatabase, seedDatabase, pool } from '../lib/db'
+import { connectRedis } from '../lib/redis'
+import { GET } from '../app/api/products/route'
+
+test('cache returns data on repeated requests', async () => {
+  const redis = await connectRedis()
+  await redis.flushDb()
+
+  await initializeDatabase()
+  await seedDatabase()
+
+  const res1 = await GET()
+  const products1 = await res1.json()
+  assert.ok(Array.isArray(products1))
+
+  const cached = await redis.get('products')
+  assert.ok(cached)
+
+  await pool.query("INSERT INTO products (name, description, price, cost, stock) VALUES ('New', '', 1, 1, 1)")
+
+  const res2 = await GET()
+  const products2 = await res2.json()
+  assert.equal(products2.length, products1.length)
+})
+


### PR DESCRIPTION
## Summary
- wrap database CRUD ops with cache-aware versions in `lib/db-cache.ts`
- switch product and center endpoints to use the cache-enabled functions
- add integration test verifying repeated calls return cached data

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a606c77883308c1e4caa1af31ef7