### PR TITLE
Improve session validation

### DIFF
--- a/components/auth-check.tsx
+++ b/components/auth-check.tsx
@@ -15,6 +15,13 @@ export default function AuthCheck({ children }: AuthCheckProps) {
   useEffect(() => {
     const checkSession = async () => {
       try {
+        const cookies = document.cookie.split('; ').map(c => c.trim())
+        const hasSession = cookies.some(c => c.startsWith('session='))
+        if (!hasSession) {
+          router.push('/login')
+          return
+        }
+
         const res = await fetch('/api/auth/check')
         const { valid } = await res.json()
         if (!valid) {

--- a/test/api-auth-check.test.ts
+++ b/test/api-auth-check.test.ts
@@ -1,12 +1,19 @@
 import { strict as assert } from 'assert'
 import { GET } from '../app/api/auth/check/route'
 
-const reqNoCookie = new Request('http://localhost')
-const resNoCookie = await GET(reqNoCookie)
-const dataNoCookie = await resNoCookie.json()
-assert.equal(dataNoCookie.valid, false)
+async function run() {
+  const reqNoCookie = new Request('http://localhost')
+  const resNoCookie = await GET(reqNoCookie)
+  const dataNoCookie = await resNoCookie.json()
+  assert.equal(dataNoCookie.valid, false)
 
-const reqCookie = new Request('http://localhost', { headers: { cookie: 'session=auth' } })
-const resCookie = await GET(reqCookie)
-const dataCookie = await resCookie.json()
-assert.equal(dataCookie.valid, true)
+  const reqCookie = new Request('http://localhost', { headers: { cookie: 'session=auth' } })
+  const resCookie = await GET(reqCookie)
+  const dataCookie = await resCookie.json()
+  assert.equal(dataCookie.valid, true)
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- check for a session cookie in `AuthCheck`
- keep server API `/api/auth/check`
- add test runner wrapper for session check route

## Testing
- `node --import tsx test/api-auth-check.test.ts && echo PASS`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849ad18b300833082a8e251d0f4af7c