### PR TITLE
Fix env loading

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod'
+import { config } from 'dotenv'
+
+// Load environment variables from .env if present
+config()
 
 const envSchema = z.object({
   DB_USER: z.string(),


### PR DESCRIPTION
## Summary
- load environment variables with `dotenv` so `pnpm run init-db` works without manual exports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849c489a53c8330844f149c90182f6c