### PR TITLE
Add CLI init for db

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ environment.
 ```bash
 pnpm run init-db
 ```
+This command runs `ts-node -P tsconfig.init.json ./lib/db.ts` which tests the
+database connection, creates the tables and seeds example data. You can also run
+the same command manually if needed:
+
+```bash
+ts-node -P tsconfig.init.json ./lib/db.ts
+```
 
 **Note**: If `psql` reports `FATAL: role "root" does not exist`, use the
 `postgres` role to connect:

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1228,3 +1228,19 @@ export const createUser = async (
     client.release()
   }
 }
+
+if (require.main === module) {
+  (async () => {
+    try {
+      await testConnection()
+      await initializeDatabase()
+      await seedDatabase()
+      console.log('Database ready')
+    } catch (err) {
+      console.error('Database initialization failed:', err)
+      process.exit(1)
+    } finally {
+      await pool.end()
+    }
+  })()
+}


### PR DESCRIPTION
## Summary
- invoke database setup when `lib/db.ts` is executed directly
- document how the init-db script works and how to run it

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849eabc13b483308f0e1c06cf555d33