### PR TITLE
Fix default admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,8 @@ DB_PASSWORD=postgres
 DB_PORT=5432
 REDIS_URL=redis://localhost:6379
 # Credentials for the built-in admin user
-# Replace these placeholders with secure values in production.
-# Do NOT use easily guessable values like 'admin' or 'admin123'.
-# These values are hashed when the database is seeded.
-ADMIN_USER=your_admin_user
-ADMIN_PASS=your_admin_password
+# These values will be hashed when the database is seeded.
+ADMIN_USER=admin
+ADMIN_PASS=admin123
 # Uncomment to serve the app under a subpath (e.g. for GitHub Pages)
 # NEXT_BASE_PATH=/accounting-distribution-system

--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ DB_NAME=accounting_system
 DB_PASSWORD=postgres
 DB_PORT=5432
 REDIS_URL=redis://localhost:6379
-ADMIN_USER=your_admin_user      # set a secure username
-ADMIN_PASS=your_admin_password  # set a strong password
+ADMIN_USER=admin      # default admin username
+ADMIN_PASS=admin123   # default admin password
 ```
 
-Avoid using trivial credentials such as `ADMIN_USER=admin` and
-`ADMIN_PASS=admin123`. Always choose unique values when setting up your
-environment.
+These credentials will be hashed when the database is initialized. Update them
+as needed for production environments.
 
 4. Initialize the database:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - DB_NAME=accounting_system
       - DB_PASSWORD=postgres_password
       - DB_PORT=5432
+      - ADMIN_USER=admin
+      - ADMIN_PASS=admin123
       # إذا كنت تريد استخدام Redis، قم بإلغاء التعليق على السطر التالي
       # - REDIS_URL=redis://redis:6379
     networks:

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -12,8 +12,8 @@ const envSchema = z.object({
   DB_PORT: z.preprocess((v) => Number(v), z.number().int()),
   REDIS_URL: z.string().url().optional(),
   // Provide secure credentials for the built-in admin user
-  ADMIN_USER: z.string().default('your_admin_user'),
-  ADMIN_PASS: z.string().default('your_admin_password'),
+  ADMIN_USER: z.string().default('admin'),
+  ADMIN_PASS: z.string().default('admin123'),
 })
 
 export const env = envSchema.parse(process.env)


### PR DESCRIPTION
## Summary
- use default credentials of `admin`/`admin123`
- update example environment file and docs
- pass admin credentials into the Docker container

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f377e274833081385b83b895aa71