### PR TITLE
Fix Nginx upstream to avoid IPv6 connection errors

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -137,7 +137,8 @@ server {
     server_name ${domain} _;
 
     location / {
-        proxy_pass http://localhost:3000;
+        # Use IPv4 loopback to avoid IPv6 connection issues
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -150,7 +151,7 @@ server {
 
     # Proxy Grafana dashboard
     location /grafana/ {
-        proxy_pass http://localhost:4000/;
+        proxy_pass http://127.0.0.1:4000/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/deploy.sh
+++ b/deploy.sh
@@ -121,7 +121,8 @@ server {
     server_name _;  # قم بتغيير هذا إلى اسم النطاق الخاص بك
     
     location / {
-        proxy_pass http://localhost:3000;
+        # Explicitly use IPv4 to prevent issues when localhost resolves to IPv6
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -16,7 +16,8 @@ server {
 
     # Proxy Grafana interface
     location /grafana/ {
-        proxy_pass http://localhost:4000/;
+        # Use IPv4 loopback since Grafana listens locally
+        proxy_pass http://127.0.0.1:4000/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -35,7 +35,8 @@ server {
     server_name $DOMAIN _;
     
     location / {
-        proxy_pass http://localhost:3000;
+        # Use an explicit IPv4 address to avoid issues when IPv6 is enabled
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -48,7 +49,8 @@ server {
 
     # Proxy Grafana dashboard
     location /grafana/ {
-        proxy_pass http://localhost:4000/;
+        # Grafana typically listens locally on port 4000
+        proxy_pass http://127.0.0.1:4000/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- use IPv4 loopback in Nginx templates to avoid connection errors when localhost resolves to IPv6

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849fabbc6b88330ae1b5dd40bd855e0