### PR TITLE
Implement Pass command in NexAccount

### DIFF
--- a/NexAccount
+++ b/NexAccount
@@ -208,6 +208,7 @@ Commands:
   Webserver  Ensure Nginx is configured and running
   Delete     Remove the PM2 process
   Log        Display recent service logs
+  Pass       Generate .env.new with system usernames
   Help       Show this help message
 
 EOF
@@ -283,6 +284,10 @@ case "$COMMAND" in
     ;;
   log|logs)
     display_logs
+    ;;
+  pass)
+    getent passwd | cut -d: -f1 > "$APP_DIR/.env.new"
+    echo "Usernames saved to $APP_DIR/.env.new"
     ;;
   help|-h|--help|"")
     show_help

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ service state along with the URLs for accessing the application.
   NexAccount Log
   ```
 
+- **Generate a usernames file**
+
+  ```bash
+  NexAccount Pass
+  ```
+
 - **Help**
 
   ```bash

--- a/test/nexaccount-pass.test.ts
+++ b/test/nexaccount-pass.test.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from 'assert'
+import fs from 'fs'
+import { execFileSync } from 'child_process'
+
+const appDir = '/var/www/accounting-system'
+fs.mkdirSync(appDir, { recursive: true })
+const envPath = `${appDir}/.env.new`
+try {
+  execFileSync('bash', ['NexAccount', 'Pass'], { cwd: process.cwd() })
+  assert.ok(fs.existsSync(envPath))
+  const content = fs.readFileSync(envPath, 'utf8')
+  assert.ok(content.includes('root'))
+} finally {
+  fs.rmSync(envPath, { force: true })
+}
+


### PR DESCRIPTION
## Summary
- add `Pass` command to NexAccount script
- generate `.env.new` file listing system usernames
- document new command in README
- add automated test for Pass command

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: env vars missing)*
- `pnpm install`


------
https://chatgpt.com/codex/tasks/task_e_684cd1ace3ec833082eea4009c07febb